### PR TITLE
Add travis build badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NUsight
 
+[![Build Status](https://travis-ci.org/NUbots/NUsight2.svg?branch=master)](https://travis-ci.org/NUbots/NUsight2)
+
 ## Dependencies
 - [Node](https://nodejs.org/en/download/)
 - [Yarn](https://yarnpkg.com/en/docs/install)


### PR DESCRIPTION
Adds a fancy live updating travis build status badge to the README 😄 

<img width="298" alt="screen shot 2017-05-13 at 2 03 20 am" src="https://cloud.githubusercontent.com/assets/132620/26006600/5fb8caae-3780-11e7-82ee-225f15f57584.png">
