### PR TITLE
Fix sourcemaps

### DIFF
--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -24,7 +24,6 @@ app.use(webpackDevMiddleware(compiler, {
 app.use(webpackHotMiddleware(compiler))
 const root = `${__dirname}/../../`
 app.use(favicon(`${__dirname}/../assets/favicon.ico`))
-// TODO (Annable): Fix this clobbering SourceMap URLs.
 app.use(fallback('dist/index.html', { root }))
 
 const port = process.env.PORT || 3000

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -10,6 +10,7 @@ const outPath = path.join(__dirname, './dist')
 
 export default {
   context: sourcePath,
+  devtool: isProduction ? false : 'inline-source-map',
   entry: {
     main: [
       './client/index.tsx',


### PR DESCRIPTION
I thought they were broken, but they just weren't turned on.

This gives you your original source code in the chrome console during debugging, rather than your transpiled ES5 code.

Old:
<img width="543" alt="screen shot 2017-05-13 at 2 33 38 am" src="https://cloud.githubusercontent.com/assets/132620/26007607/9d691dbe-3784-11e7-8b32-14def0c71d55.png">


New:
<img width="722" alt="screen shot 2017-05-13 at 2 28 43 am" src="https://cloud.githubusercontent.com/assets/132620/26007475/f7707704-3783-11e7-85c6-c424c4b4326e.png">

