### PR TITLE
Disable travis emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
 node_js:
-  - "7"
+  - '7'
 branches:
   only:
-    - "master"
+    - 'master'
+notifications:
+  email: false
 script:
     - yarn tslint
     - yarn build


### PR DESCRIPTION
I don't think the emails will be necessary as you can see the status of builds right within PRs.