### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,6 @@
 # This is the top-most EditorConfig file
 root = true
 
-# Unix-style newlines with indentation of 2 spaces
 [*]
 end_of_line = lf
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# More info: http://EditorConfig.org
+
+# This is the top-most EditorConfig file
+root = true
+
+# Unix-style newlines with indentation of 2 spaces
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ root = true
 end_of_line = lf
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8


### PR DESCRIPTION
EditorConfig (http://editorconfig.org/) allows for configuring code style conventions across different editors. The file I've added ensures that indents are 2 spaces and files use Unix-style (LF) line endings (these can be changed).

I use Sublime on Windows at the moment (downloading IntelliJ @TrentHouliston 😄)  and this allows me to automatically have Unix-style line endings and consistent indents.

EditorConfig is already supported by IntelliJ IDEA and there are plugins (http://editorconfig.org/#download) for most editors/IDEs.