### PR TITLE
Make nodemon ignore client-side changes

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,7 @@
+{
+  "verbose": true,
+  "ignore": ["*.tests.ts", "src/client"],
+  "execMap": {
+    "ts": "ts-node"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "coverage": "yarn test -- --coverage",
     "coverage:ci": "yarn test:ci -- --coverage",
     "tslint": "tslint -c tslint.json 'src/**/*.ts'",
-    "start": "nodemon --exec ts-node ./src/server/dev.ts",
+    "tslint:fix": "tslint -c tslint.json 'src/**/*.ts' --fix",
+    "start": "nodemon ./src/server/dev.ts",
     "prod": "ts-node -F ./src/server/prod.ts",
     "build": "webpack -p --progress --colors",
     "heroku-postbuild": "yarn build"


### PR DESCRIPTION
Currently nodemon will restart the entire server when you make client-side changes, i.e. edit a file in `src/client`.

This is unneeded and makes development slow! So this PR makes nodemon ignore both tests and anything in `src/client`.