### PR TITLE
Fix fallback history api

### DIFF
--- a/declarations/connect-history-api-fallback.d.ts
+++ b/declarations/connect-history-api-fallback.d.ts
@@ -1,0 +1,4 @@
+declare module 'connect-history-api-fallback' {
+  const value: () => any
+  export = value
+}

--- a/declarations/express-history-api-fallback.d.ts
+++ b/declarations/express-history-api-fallback.d.ts
@@ -1,4 +1,0 @@
-declare module 'express-history-api-fallback' {
-  const value: (path: string, opts: any) => any
-  export = value
-}

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "compression": "^1.6.2",
+    "connect-history-api-fallback": "^1.3.0",
     "express": "^4.15.2",
-    "express-history-api-fallback": "^2.1.0",
     "mobx": "^3.1.0",
     "mobx-react": "^4.1.0",
     "mobx-react-router": "^3.1.2",

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -23,10 +23,12 @@ const devMiddleware = webpackDevMiddleware(compiler, {
 })
 
 app.use(compression())
-// See https://github.com/webpack/webpack-dev-middleware/pull/44
-app.use(history())
+// We need to wrap the fallback history API with two instances of the dev middleware to handle the initial raw request
+// and the following rewritten request.
+// Refer to: https://github.com/webpack/webpack-dev-middleware/pull/44#issuecomment-170462282
 app.use(devMiddleware)
 app.use(history())
+app.use(devMiddleware)
 app.use(webpackHotMiddleware(compiler))
 app.use(favicon(`${__dirname}/../assets/favicon.ico`))
 

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -1,6 +1,6 @@
 import * as compression from 'compression'
+import * as history from 'connect-history-api-fallback'
 import * as express from 'express'
-import * as fallback from 'express-history-api-fallback'
 import * as http from 'http'
 import * as favicon from 'serve-favicon'
 import * as sio from 'socket.io'
@@ -14,18 +14,21 @@ const app = express()
 const server = http.createServer(app)
 sio(server)
 
-app.use(compression())
-app.use(webpackDevMiddleware(compiler, {
+const devMiddleware = webpackDevMiddleware(compiler, {
   publicPath: '/',
   index: 'index.html',
   stats: {
     colors: true,
   },
-}))
+})
+
+app.use(compression())
+// See https://github.com/webpack/webpack-dev-middleware/pull/44
+app.use(history())
+app.use(devMiddleware)
+app.use(history())
 app.use(webpackHotMiddleware(compiler))
-const root = `${__dirname}/../../`
 app.use(favicon(`${__dirname}/../assets/favicon.ico`))
-app.use(fallback('dist/index.html', { root }))
 
 const port = process.env.PORT || 3000
 server.listen(port, () => {

--- a/src/server/prod.ts
+++ b/src/server/prod.ts
@@ -1,11 +1,12 @@
 import * as compression from 'compression'
+import * as history from 'connect-history-api-fallback'
 import * as express from 'express'
-import * as fallback from 'express-history-api-fallback'
 import * as http from 'http'
 import * as favicon from 'serve-favicon'
 import * as sio from 'socket.io'
 
 const app = express()
+app.use(history())
 const server = http.createServer(app)
 sio(server)
 
@@ -13,7 +14,6 @@ const root = `${__dirname}/../../dist`
 app.use(compression())
 app.use(express.static(root))
 app.use(favicon(`${__dirname}/../assets/favicon.ico`))
-app.use(fallback('index.html', { root }))
 
 const port = process.env.PORT || 9090
 server.listen(port, () => {

--- a/src/server/prod.ts
+++ b/src/server/prod.ts
@@ -6,11 +6,11 @@ import * as favicon from 'serve-favicon'
 import * as sio from 'socket.io'
 
 const app = express()
-app.use(history())
 const server = http.createServer(app)
 sio(server)
 
 const root = `${__dirname}/../../dist`
+app.use(history())
 app.use(compression())
 app.use(express.static(root))
 app.use(favicon(`${__dirname}/../assets/favicon.ico`))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,10 +2133,6 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-express-history-api-fallback@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/express-history-api-fallback/-/express-history-api-fallback-2.1.0.tgz#3bed00cf8a3a3baa85c1d43357c28762eb6185ac"
-
 express@^4.13.3, express@^4.15.2:
   version "4.15.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.15.2.tgz#af107fc148504457f2dca9a6f2571d7129b97b35"


### PR DESCRIPTION
- Replace express-history-api-fallback with connect-history-api-fallback.
- Update usages in dev and prod servers.
- Add custom typings for connect-history-api-fallback.