### PR TITLE
Rename dist to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_STORE
 node_modules
 .module-cache
-dist
+build
 
 # IntelliJ IDEA
 /.idea/workspace.xml

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "tslint:fix": "tslint -c tslint.json 'src/**/*.ts' --fix",
     "start": "nodemon ./src/server/dev.ts",
     "prod": "ts-node -F ./src/server/prod.ts",
-    "build": "webpack -p --progress --colors",
+    "build": "rimraf build && webpack -p --progress --colors",
     "heroku-postbuild": "yarn build"
   },
   "license": "MIT",
@@ -65,6 +65,7 @@
     "postcss-url": "^5.1.2",
     "react-hot-loader": "^1.3.1",
     "react-svg-loader": "^1.1.1",
+    "rimraf": "^2.6.1",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.10.0",
     "style-loader": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "tslint:fix": "tslint -c tslint.json 'src/**/*.ts' --fix",
     "start": "nodemon ./src/server/dev.ts",
     "prod": "ts-node -F ./src/server/prod.ts",
-    "build": "yarn run clean:build && webpack -p --progress --colors",
+    "build": "yarn clean:build && webpack -p --progress --colors",
     "clean": "yarn clean:build && yarn clean:coverage",
     "clean:build": "rimraf build",
     "clean:coverage": "rimraf coverage",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "tslint:fix": "tslint -c tslint.json 'src/**/*.ts' --fix",
     "start": "nodemon ./src/server/dev.ts",
     "prod": "ts-node -F ./src/server/prod.ts",
-    "build": "rimraf build && webpack -p --progress --colors",
+    "build": "yarn run clean:build && webpack -p --progress --colors",
+    "clean": "yarn clean:build && yarn clean:coverage",
+    "clean:build": "rimraf build",
+    "clean:coverage": "rimraf coverage",
     "heroku-postbuild": "yarn build"
   },
   "license": "MIT",

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -25,7 +25,7 @@ app.use(webpackDevMiddleware(compiler, {
 app.use(webpackHotMiddleware(compiler))
 const root = `${__dirname}/../../`
 app.use(favicon(`${__dirname}/../assets/favicon.ico`))
-app.use(fallback('dist/index.html', { root }))
+app.use(fallback('build/index.html', { root }))
 
 const port = process.env.PORT || 3000
 server.listen(port, () => {

--- a/src/server/prod.ts
+++ b/src/server/prod.ts
@@ -9,7 +9,7 @@ const app = express()
 const server = http.createServer(app)
 sio(server)
 
-const root = `${__dirname}/../../dist`
+const root = `${__dirname}/../../build`
 app.use(compression())
 app.use(express.static(root))
 app.use(favicon(`${__dirname}/../assets/favicon.ico`))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "src"
   ],
   "exclude": [
-    "dist",
+    "build",
     "node_modules"
   ],
   "awesomeTypescriptLoaderOptions": {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -6,7 +6,7 @@ import * as webpack from 'webpack'
 
 const isProduction = process.argv.indexOf('-p') >= 0
 const sourcePath = path.join(__dirname, './src')
-const outPath = path.join(__dirname, './dist')
+const outPath = path.join(__dirname, './build')
 
 export default {
   context: sourcePath,


### PR DESCRIPTION
We don't have a distribution (we're not a library)... so build makes more sense.

Also removes any existing `build` dir on a build