### PR TITLE
Add all libraries to vendor bundle

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -18,12 +18,15 @@ export default {
       'webpack-hot-middleware/client',
     ]),
     vendor: [
-      'react',
-      'react-dom',
-      'react-router',
+      'classnames',
       'mobx',
       'mobx-react',
       'mobx-react-router',
+      'react',
+      'react-dom',
+      'react-router',
+      'socket.io-client',
+      'three',
     ],
   },
   output: {


### PR DESCRIPTION
Ensures client-side libraries are added to `vendor.bundle.js` instead of `bundle.js`.