### PR TITLE
Upgrade mobx-react-devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^20.0.1",
     "jest-css-modules": "^1.1.0",
-    "mobx-react-devtools": "^4.2.11",
+    "mobx-react-devtools": "^4.2.13",
     "nodemon": "^1.11.0",
     "postcss": "^5.2.15",
     "postcss-browser-reporter": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3750,9 +3750,9 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-mobx-react-devtools@^4.2.11:
-  version "4.2.11"
-  resolved "https://registry.yarnpkg.com/mobx-react-devtools/-/mobx-react-devtools-4.2.11.tgz#18d89a32b7d28b48228d12ccde73cf733aacc395"
+mobx-react-devtools@^4.2.13:
+  version "4.2.13"
+  resolved "https://registry.yarnpkg.com/mobx-react-devtools/-/mobx-react-devtools-4.2.13.tgz#44b8bab566cefb199136770ca65278c646bbb0b5"
 
 mobx-react-router@^3.1.2:
   version "3.1.2"


### PR DESCRIPTION
* Fixes the console deprecation warning regarding PropTypes