### PR TITLE
Add reusable menu bar

### DIFF
--- a/src/client/components/localisation/style.css
+++ b/src/client/components/localisation/style.css
@@ -10,7 +10,7 @@
 	list-style-type: none;
 	margin: 0;
 	padding: 0;
-	height: 60px;
+	height: inherit;
 	display: flex;
 	align-items: stretch;
 }

--- a/src/client/components/localisation/view.tsx
+++ b/src/client/components/localisation/view.tsx
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react'
 import * as React from 'react'
 import { WebGLRenderer } from 'three'
 import { inject } from '../../../inversify.config'
+import { MenuBar } from '../menu_bar/view'
 import { LocalisationController } from './controller'
 import { LocalisationModel } from './model'
 import { ViewMode } from './model'
@@ -57,7 +58,7 @@ export class LocalisationView extends React.Component<LocalisationViewProps, any
   public render(): JSX.Element {
     return (
         <div className={style.localisation}>
-          <MenuBar onHawkEyeClick={this.onHawkEyeClick}/>
+          <LocalisationMenuBar onHawkEyeClick={this.onHawkEyeClick}/>
           <div className={style.localisation__canvasContainer}>
             <canvas className={style.localisation__canvas} ref={canvas => {
               this.canvas = canvas
@@ -129,17 +130,19 @@ export class LocalisationView extends React.Component<LocalisationViewProps, any
   }
 }
 
-interface MenuBarProps {
+interface LocalisationMenuBarProps {
   onHawkEyeClick(): void
 }
 
-const MenuBar = observer((props: MenuBarProps) => {
+const LocalisationMenuBar = observer((props: LocalisationMenuBarProps) => {
   return (
+    <MenuBar>
       <ul className={style.localisation__menu}>
         <li className={style.localisation__menuItem}>
           <button className={style.localisation__menuButton} onClick={props.onHawkEyeClick}>Hawk Eye</button>
         </li>
       </ul>
+    </MenuBar>
   )
 })
 

--- a/src/client/components/menu_bar/style.css
+++ b/src/client/components/menu_bar/style.css
@@ -1,0 +1,4 @@
+.menuBar {
+  display: flex;
+  height: 60px;
+}

--- a/src/client/components/menu_bar/view.tsx
+++ b/src/client/components/menu_bar/view.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react'
+import { HTMLProps } from 'react'
+import * as style from './style.css'
+
+export type MenuBarProps = HTMLProps<JSX.Element>
+
+export const MenuBar = (props: MenuBarProps) => {
+  return (
+    <div className={style.menuBar}>
+      {props.children}
+    </div>
+  )
+}


### PR DESCRIPTION
Extract simple menu bar component from localisation view so that other screens, such as configuration, can make use of it.