### PR TITLE
Cache yarn to speed up the build in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,14 @@ node_js:
   - '6'
   - '7'
   - '8'
+
+# Cache yarn and node_modules to speed up the build
 cache:
   yarn: true
   directories:
     - node_modules
+
+# We need to set this so our compiler is g++-4.9 for NUClearNet.js
 env:
   - CXX=g++-4.9
 addons:
@@ -18,9 +22,13 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.9
+
+# Only build the master branch, PRs will build also due to settings in the web ui
 branches:
   only:
     - 'master'
+
+# Don't spam people with emails
 notifications:
   email: false
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ node_js:
   - '6'
   - '7'
   - '8'
-cache: yarn
+cache:
+  yarn: true
+  directories:
+    - node_modules
 env:
   - CXX=g++-4.9
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - '6'
   - '7'
   - '8'
+cache: yarn
 env:
   - CXX=g++-4.9
 addons:


### PR DESCRIPTION
By letting travis cache yarn dependencies we can speed up the build in travis a little.