### PR TITLE
Update jest to ignore proto directory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,9 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', 'src/global.d.ts'],
   collectCoverageFrom: [
     '**/*.{ts,tsx}',
+    '!src/shared/proto/**',
     '!**/node_modules/**',
     '!**/tests/**',
-    '!tools/**'
   ],
   globals: {
     __TS_CONFIG__: './tsconfig.test.json'


### PR DESCRIPTION
CI is currently showing an error:

[`Failed to collect coverage from src/shared/proto/messages.d.ts`](https://travis-ci.org/NUbots/NUsight2/jobs/244400149#L377)

We don't need CI to run on the proto folder, so this PR updates the configuration to ignore it.