### PR TITLE
Enable source maps on production

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -10,7 +10,7 @@ const outPath = path.join(__dirname, './build')
 
 export default {
   context: sourcePath,
-  devtool: isProduction ? false : 'inline-source-map',
+  devtool: isProduction ? 'source-map' : 'inline-source-map',
   entry: {
     main: [
       'reflect-metadata',


### PR DESCRIPTION
Lets us use the debugger on https://nusight.herokuapp.com/