### PR TITLE
Remove node modules cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,9 @@ node_js:
   - '7'
   - '8'
 
-# Cache yarn and node_modules to speed up the build
+# Cache yarn to speed up the build
 cache:
   yarn: true
-  directories:
-    - node_modules
 
 # We need to set this so our compiler is g++-4.9 for NUClearNet.js
 env:

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -13,7 +13,6 @@ import { RobotSimulator } from '../simulators/robot_simulator'
 import { SimulatorStatus } from '../simulators/robot_simulator'
 import { SensorDataSimulator } from '../simulators/sensor_data_simulator'
 import { NUSightServer } from './app/server'
-import CloseTo = Chai.CloseTo
 
 const compiler = webpack(webpackConfig)
 


### PR DESCRIPTION
Travis was passing because it was caching `node_modules`, even when a dependency was deleted.

This removes the `node_modules` cache. It wasn't speeding up builds significantly enough to warrant potential false-positive builds.

First commit fails, as expected, then the second commit fixes the actual build error.