### PR TITLE
Add networked robots

### DIFF
--- a/src/client/components/app/network.ts
+++ b/src/client/components/app/network.ts
@@ -1,0 +1,62 @@
+import { action } from 'mobx'
+import { NUClearNetPeer } from 'nuclearnet.js'
+import { NUsightNetwork } from '../../network/nusight_network'
+import { RobotModel } from '../robot/model'
+import { AppModel } from './model'
+
+export class AppNetwork {
+  public constructor(private nusightNetwork: NUsightNetwork,
+                     private model: AppModel) {
+    nusightNetwork.onNUClearJoin(this.onJoin)
+    nusightNetwork.onNUClearLeave(this.onLeave)
+  }
+
+  public static of(nusightNetwork: NUsightNetwork, model: AppModel) {
+    return new AppNetwork(nusightNetwork, model)
+  }
+
+  @action
+  private onJoin = (peer: NUClearNetPeer) => {
+    if (peer.name === 'nusight') {
+      return
+    }
+
+    const robot = this.findRobot(peer)
+
+    if (robot) {
+      robot.connected = true
+    } else {
+      this.model.robots.push(RobotModel.of({
+        name: peer.name,
+        address: peer.address,
+        port: peer.port,
+        connected: true,
+        enabled: true, // TODO (Annable): Only automatically enable robots that have connected shortly after load.
+      }))
+    }
+  }
+
+  private onLeave = (peer: NUClearNetPeer) => {
+    if (peer.name === 'nusight') {
+      return
+    }
+
+    const robot = this.model.robots.find(otherRobot => {
+      return otherRobot.name === peer.name && otherRobot.address === peer.address && otherRobot.port === peer.port
+    })
+    if (robot) {
+      robot.connected = false
+    }
+  }
+
+  private findRobot(peer: NUClearNetPeer): RobotModel | undefined {
+    let candidates = this.model.robots.filter(otherRobot => {
+      return otherRobot.name === peer.name && otherRobot.address === peer.address
+    })
+    /*
+     * Robots are not always uniquely identifiable across connections since they may have the same name and address.
+     * We essentially guess and pick the first candidate.
+     */
+    return candidates.length > 0 ? candidates[0] : undefined
+  }
+}

--- a/src/client/components/localisation/controller.ts
+++ b/src/client/components/localisation/controller.ts
@@ -263,11 +263,13 @@ export class LocalisationController {
   }
 
   private getNextTarget(model: LocalisationModel) {
+    // TODO (Annable): ignore robots with visible === false
     const targetIndex = model.robots.findIndex(robot => robot === model.target)
     return model.robots[targetIndex + 1] || model.robots[0]
   }
 
   private getPreviousTarget(model: LocalisationModel) {
+    // TODO (Annable): ignore robots with visible === false
     const targetIndex = model.robots.findIndex(robot => robot === model.target)
     return model.robots[targetIndex - 1] || model.robots[model.robots.length - 1]
   }

--- a/src/client/components/localisation/darwin_robot/body/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/body/view_model.ts
@@ -6,16 +6,16 @@ import { geometryAndMaterial } from '../../utils'
 import { HeadViewModel } from '../head/view_model'
 import { LeftArmViewModel } from '../left_arm/view_model'
 import { LeftLegViewModel } from '../left_leg/view_model'
-import { RobotModel } from '../model'
+import { LocalisationRobotModel } from '../model'
 import { RightArmViewModel } from '../right_arm/view_model'
 import { RightLegViewModel } from '../right_leg/view_model'
 import * as BodyConfig from './config/body.json'
 
 export class BodyViewModel {
-  public constructor(private model: RobotModel) {
+  public constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: RobotModel): BodyViewModel => {
+  public static of = createTransformer((model: LocalisationRobotModel): BodyViewModel => {
     return new BodyViewModel(model)
   })
 

--- a/src/client/components/localisation/darwin_robot/head/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/head/view_model.ts
@@ -4,7 +4,7 @@ import { Mesh } from 'three'
 import { MultiMaterial } from 'three'
 import { Object3D } from 'three'
 import { geometryAndMaterial } from '../../utils'
-import { RobotModel } from '../model'
+import { LocalisationRobotModel } from '../model'
 import * as CameraConfig from './config/camera.json'
 import * as EyeLEDConfig from './config/eye_led.json'
 import * as HeadConfig from './config/head.json'
@@ -12,10 +12,10 @@ import * as HeadLEDConfig from './config/head_led.json'
 import * as NeckConfig from './config/neck.json'
 
 export class HeadViewModel {
-  constructor(private model: RobotModel) {
+  constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: RobotModel): HeadViewModel => {
+  public static of = createTransformer((model: LocalisationRobotModel): HeadViewModel => {
     return new HeadViewModel(model)
   })
 

--- a/src/client/components/localisation/darwin_robot/left_arm/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/left_arm/view_model.ts
@@ -4,16 +4,16 @@ import { Mesh } from 'three'
 import { MultiMaterial } from 'three'
 import { Object3D } from 'three'
 import { geometryAndMaterial } from '../../utils'
-import { RobotModel } from '../model'
+import { LocalisationRobotModel } from '../model'
 import * as LeftLowerArmConfig from './config/left_lower_arm.json'
 import * as LeftShoulderConfig from './config/left_shoulder.json'
 import * as LeftUpperArmConfig from './config/left_upper_arm.json'
 
 export class LeftArmViewModel {
-  constructor(private model: RobotModel) {
+  constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: RobotModel): LeftArmViewModel => {
+  public static of = createTransformer((model: LocalisationRobotModel): LeftArmViewModel => {
     return new LeftArmViewModel(model)
   })
 

--- a/src/client/components/localisation/darwin_robot/left_leg/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/left_leg/view_model.ts
@@ -4,7 +4,7 @@ import { Mesh } from 'three'
 import { MultiMaterial } from 'three'
 import { Object3D } from 'three'
 import { geometryAndMaterial } from '../../utils'
-import { RobotModel } from '../model'
+import { LocalisationRobotModel } from '../model'
 import * as LeftAnkleConfig from './config/left_ankle.json'
 import * as LeftFootConfig from './config/left_foot.json'
 import * as LeftLowerLegConfig from './config/left_lower_leg.json'
@@ -13,10 +13,10 @@ import * as LeftPelvisYConfig from './config/left_pelvis_y.json'
 import * as LeftUpperLegConfig from './config/left_upper_leg.json'
 
 export class LeftLegViewModel {
-  constructor(private model: RobotModel) {
+  constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: RobotModel): LeftLegViewModel => {
+  public static of = createTransformer((model: LocalisationRobotModel): LeftLegViewModel => {
     return new LeftLegViewModel(model)
   })
 

--- a/src/client/components/localisation/darwin_robot/model.ts
+++ b/src/client/components/localisation/darwin_robot/model.ts
@@ -1,28 +1,37 @@
 import { observable } from 'mobx'
+import { createTransformer } from 'mobx'
+import { RobotModel } from '../../robot/model'
 import { Vector3 } from '../model'
+import { computed } from 'mobx'
 
-export class RobotModel {
-  @observable public id: number
+export class LocalisationRobotModel {
+  @observable private model: RobotModel
   @observable public name: string
   @observable public color?: string
   @observable public heading: number
   @observable public position: Vector3
   @observable public motors: DarwinMotorSet
 
-  public constructor(opts: RobotModel) {
+  public constructor(model: RobotModel, opts: Partial<LocalisationRobotModel>) {
+    this.model = model
     Object.assign(this, opts)
   }
 
-  public static of(opts: { id: number, name: string, color?: string, heading: number }) {
-    return new RobotModel({
-      ...opts,
+  public static of = createTransformer((model: RobotModel): LocalisationRobotModel => {
+    return new LocalisationRobotModel(model, {
+      name: model.name,
+      heading: 0,
       position: Vector3.of(),
       motors: DarwinMotorSet.of(),
     })
+  })
+
+  @computed get visible() {
+    return this.model.enabled
   }
 }
 
-class DarwinMotorSet {
+export class DarwinMotorSet {
   @observable public rightShoulderPitch: DarwinMotor
   @observable public leftShoulderPitch: DarwinMotor
   @observable public rightShoulderRoll: DarwinMotor

--- a/src/client/components/localisation/darwin_robot/right_arm/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/right_arm/view_model.ts
@@ -4,16 +4,16 @@ import { Mesh } from 'three'
 import { MultiMaterial } from 'three'
 import { Object3D } from 'three'
 import { geometryAndMaterial } from '../../utils'
-import { RobotModel } from '../model'
+import { LocalisationRobotModel } from '../model'
 import * as RightLowerArmConfig from './config/right_lower_arm.json'
 import * as RightShoulderConfig from './config/right_shoulder.json'
 import * as RightUpperArmConfig from './config/right_upper_arm.json'
 
 export class RightArmViewModel {
-  constructor(private model: RobotModel) {
+  constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: RobotModel): RightArmViewModel => {
+  public static of = createTransformer((model: LocalisationRobotModel): RightArmViewModel => {
     return new RightArmViewModel(model)
   })
 

--- a/src/client/components/localisation/darwin_robot/right_leg/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/right_leg/view_model.ts
@@ -4,7 +4,7 @@ import { Mesh } from 'three'
 import { MultiMaterial } from 'three'
 import { Object3D } from 'three'
 import { geometryAndMaterial } from '../../utils'
-import { RobotModel } from '../model'
+import { LocalisationRobotModel } from '../model'
 import * as RightAnkleConfig from './config/right_ankle.json'
 import * as RightFootConfig from './config/right_foot.json'
 import * as RightLowerLegConfig from './config/right_lower_leg.json'
@@ -13,10 +13,10 @@ import * as RightPelvisYConfig from './config/right_pelvis_y.json'
 import * as RightUpperLegConfig from './config/right_upper_leg.json'
 
 export class RightLegViewModel {
-  constructor(private model: RobotModel) {
+  constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: RobotModel): RightLegViewModel => {
+  public static of = createTransformer((model: LocalisationRobotModel): RightLegViewModel => {
     return new RightLegViewModel(model)
   })
 

--- a/src/client/components/localisation/darwin_robot/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/view_model.ts
@@ -2,15 +2,15 @@ import { computed } from 'mobx'
 import { createTransformer } from 'mobx'
 import { Object3D } from 'three'
 import { BodyViewModel } from './body/view_model'
-import { RobotModel } from './model'
+import { LocalisationRobotModel } from './model'
 
 export const HIP_TO_FOOT = 0.2465
 
 export class RobotViewModel {
-  public constructor(private model: RobotModel) {
+  public constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: RobotModel): RobotViewModel => {
+  public static of = createTransformer((model: LocalisationRobotModel): RobotViewModel => {
     return new RobotViewModel(model)
   })
 

--- a/src/client/components/localisation/model.ts
+++ b/src/client/components/localisation/model.ts
@@ -1,8 +1,9 @@
 import { action, observable } from 'mobx'
 import { computed } from 'mobx'
-import { RobotModel } from './darwin_robot/model'
+import { LocalisationRobotModel } from './darwin_robot/model'
 import { FieldModel } from './field/model'
 import { SkyboxModel } from './skybox/model'
+import { AppModel } from '../app/model'
 
 export class TimeModel {
   @observable public time: number // seconds
@@ -31,25 +32,25 @@ export enum ViewMode {
 }
 
 export class LocalisationModel {
+  @observable private appModel: AppModel
   @observable public aspect: number
-  @observable public robots: RobotModel[]
   @observable public field: FieldModel
   @observable public skybox: SkyboxModel
   @observable public camera: CameraModel
   @observable public locked: boolean
   @observable public controls: ControlsModel
   @observable public viewMode: ViewMode
-  @observable public target?: RobotModel
+  @observable public target?: LocalisationRobotModel
   @observable public time: TimeModel
 
-  constructor(opts: LocalisationModel) {
+  constructor(appModel: AppModel, opts: Partial<LocalisationModel>) {
+    this.appModel = appModel
     Object.assign(this, opts)
   }
 
-  public static of(): LocalisationModel {
-    return new LocalisationModel({
+  public static of(appModel: AppModel): LocalisationModel {
+    return new LocalisationModel(appModel, {
       aspect: 300 / 150,
-      robots: [],
       field: FieldModel.of(),
       skybox: SkyboxModel.of(),
       camera: CameraModel.of(),
@@ -58,6 +59,10 @@ export class LocalisationModel {
       viewMode: ViewMode.FreeCamera,
       time: TimeModel.of(),
     })
+  }
+
+  @computed get robots(): LocalisationRobotModel[] {
+    return this.appModel.robots.map(robot => LocalisationRobotModel.of(robot))
   }
 }
 
@@ -73,9 +78,9 @@ class CameraModel {
 
   public static of() {
     return new CameraModel({
-      position: Vector3.of(),
+      position: new Vector3(0, 1, 1),
       yaw: 0,
-      pitch: 0,
+      pitch: 0.5,
       distance: 0.5,
     })
   }

--- a/src/client/components/localisation/network.ts
+++ b/src/client/components/localisation/network.ts
@@ -2,8 +2,10 @@ import { action } from 'mobx'
 import { message } from '../../../shared/proto/messages'
 import { Network } from '../../network/network'
 import { NUsightNetwork } from '../../network/nusight_network'
+import { RobotModel } from '../robot/model'
 import { LocalisationModel } from './model'
 import Sensors = message.input.Sensors
+import { LocalisationRobotModel } from './darwin_robot/model'
 
 export class LocalisationNetwork {
   public constructor(private network: Network,
@@ -21,9 +23,8 @@ export class LocalisationNetwork {
   }
 
   @action
-  private onSensors = (sensors: Sensors) => {
-    // TODO (Annable): Remove hardcoded values.
-    const robot = this.model.robots[0]
+  private onSensors = (robotModel: RobotModel, sensors: Sensors) => {
+    const robot = LocalisationRobotModel.of(robotModel)
     robot.motors.rightShoulderPitch.angle = Number(sensors.servo[0].presentPosition)
     robot.motors.leftShoulderPitch.angle = Number(sensors.servo[1].presentPosition)
     robot.motors.rightShoulderRoll.angle = Number(sensors.servo[2].presentPosition)

--- a/src/client/components/localisation/tests/controller.tests.ts
+++ b/src/client/components/localisation/tests/controller.tests.ts
@@ -1,3 +1,5 @@
+import { createMockInstance } from '../../../../shared/base/testing/create_mock_instance'
+import { AppModel } from '../../app/model'
 import { LocalisationController } from '../controller'
 import { LocalisationModel } from '../model'
 import { ViewMode } from '../model'
@@ -7,7 +9,7 @@ describe('LocalisationController', () => {
   let model: LocalisationModel
 
   beforeEach(() => {
-    model = LocalisationModel.of()
+    model = LocalisationModel.of(createMockInstance(AppModel))
     controller = new LocalisationController()
   })
 

--- a/src/client/components/localisation/view_model.ts
+++ b/src/client/components/localisation/view_model.ts
@@ -45,7 +45,9 @@ export class LocalisationViewModel {
 
   @computed
   private get robots(): Object3D[] {
-    return this.model.robots.map(robotModel => RobotViewModel.of(robotModel).robot)
+    return this.model.robots
+      .filter(robotModel => robotModel.visible)
+      .map(robotModel => RobotViewModel.of(robotModel).robot)
   }
 
   @computed

--- a/src/client/components/robot/model.ts
+++ b/src/client/components/robot/model.ts
@@ -1,9 +1,11 @@
 import { observable } from 'mobx'
 
 export class RobotModel {
+  @observable public connected: boolean
   @observable public enabled: boolean
   @observable public name: string
-  @observable public host: string
+  @observable public address: string
+  @observable public port: number
 
   public constructor(opts: RobotModel) {
     Object.assign(this, opts)

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1,5 +1,4 @@
 import { useStrict } from 'mobx'
-import { runInAction } from 'mobx'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { BrowserRouter } from 'react-router-dom'
@@ -7,19 +6,18 @@ import { Route } from 'react-router-dom'
 import { Switch } from 'react-router-dom'
 import { AppController } from './components/app/controller'
 import { AppModel } from './components/app/model'
+import { AppNetwork } from './components/app/network'
 import { AppView } from './components/app/view'
 import { Chart } from './components/chart/view'
 import { Classifier } from './components/classifier/view'
 import { Dashboard } from './components/dashboard/view'
 import { GameState } from './components/game_state/view'
 import { LocalisationController } from './components/localisation/controller'
-import { RobotModel as LocalisationRobotModel } from './components/localisation/darwin_robot/model'
 import { LocalisationModel } from './components/localisation/model'
 import { LocalisationNetwork } from './components/localisation/network'
 import { LocalisationView } from './components/localisation/view'
 import { withRobotSelectorMenuBar } from './components/menu_bar/view'
 import { NUClear } from './components/nuclear/view'
-import { RobotModel } from './components/robot/model'
 import { Scatter } from './components/scatter_plot/view'
 import { Subsumption } from './components/subsumption/view'
 import { Vision } from './components/vision/view'
@@ -28,47 +26,14 @@ import { NUsightNetwork } from './network/nusight_network'
 // enable MobX strict mode
 useStrict(true)
 
-const nusightNetwork = NUsightNetwork.of()
+const appModel = AppModel.of()
+const nusightNetwork = NUsightNetwork.of(appModel)
 nusightNetwork.connect({ name: 'nusight' })
 
-// TODO (Annable): Replace all this code with real networking + simulator
-const localisationModel = LocalisationModel.of()
-const appModel = AppModel.of({
-  robots: [
-    RobotModel.of({ enabled: false, name: 'Robot 1', host: 'localhost' }),
-    RobotModel.of({ enabled: false, name: 'Robot 2', host: 'localhost' }),
-    RobotModel.of({ enabled: false, name: 'Robot 3', host: 'localhost' }),
-  ],
-})
-
-runInAction(() => {
-  localisationModel.camera.position.set(0, 0.2, 0.5)
-
-  const colors = [undefined, 'magenta', undefined, 'blue', undefined, 'cyan', undefined, 'red']
-  const numRobots = 8
-  new Array(numRobots).fill(0).map((_, id) => {
-    const robot = LocalisationRobotModel.of({ id, name: `Robot ${id + 1}`, color: colors[id] || undefined, heading: 0 })
-    localisationModel.robots.push(robot)
-    return robot
-  })
-})
-
-requestAnimationFrame(function update() {
-  requestAnimationFrame(update)
-  runInAction(() => {
-    const numRobots = localisationModel.robots.length
-    localisationModel.robots.forEach((robot, i) => {
-
-      const angle = i * (2 * Math.PI) / numRobots + Date.now() / 4E4
-      const distance = Math.cos(Date.now() / 1E3 + 4 * i) * 0.3 + 1
-      robot.position.x = distance * Math.cos(angle)
-      robot.position.z = distance * Math.sin(angle)
-      robot.heading = -angle - Math.PI / 2
-    })
-  })
-})
+const localisationModel = LocalisationModel.of(appModel)
 
 const appController = AppController.of()
+AppNetwork.of(nusightNetwork, appModel)
 const menu = withRobotSelectorMenuBar(appModel.robots, appController.toggleRobotEnabled)
 
 ReactDOM.render(
@@ -94,3 +59,4 @@ ReactDOM.render(
   </BrowserRouter>,
   document.getElementById('root'),
 )
+

--- a/src/client/nuclearnet/web_socket_client.ts
+++ b/src/client/nuclearnet/web_socket_client.ts
@@ -7,17 +7,16 @@ import * as SocketIO from 'socket.io-client'
  * There should never be enough logic in here that it needs any testing.
  */
 export class WebSocketClient {
-  private socket: SocketIOClient.Socket
-
-  public constructor() {
+  public constructor(private socket: SocketIOClient.Socket) {
   }
 
-  public static of() {
-    return new WebSocketClient()
+  public static of(uri: string, opts: SocketIOClient.ConnectOpts) {
+    const socket = SocketIO(uri, opts)
+    return new WebSocketClient(socket)
   }
 
-  public connect(uri: string, opts?: SocketIOClient.ConnectOpts) {
-    this.socket = SocketIO.connect(uri, opts)
+  public connect() {
+    this.socket = this.socket.connect()
   }
 
   public disconnect() {

--- a/src/client/nuclearnet/web_socket_proxy_nuclearnet_client.ts
+++ b/src/client/nuclearnet/web_socket_proxy_nuclearnet_client.ts
@@ -27,17 +27,18 @@ export class WebSocketProxyNUClearNetClient implements NUClearNetClient {
   }
 
   public static of() {
-    return new WebSocketProxyNUClearNetClient(WebSocketClient.of())
+    const uri = `${document.location.origin}/nuclearnet`
+    return new WebSocketProxyNUClearNetClient(WebSocketClient.of(uri, {
+      upgrade: false,
+      transports: ['websocket'],
+    }))
   }
 
   public connect(options: NUClearNetOptions): () => void {
-    this.socket.connect(`${document.location.origin}/nuclearnet`, {
-      upgrade: false,
-      transports: ['websocket'],
-    })
-
+    this.socket.connect()
     this.socket.on('reconnect', this.onReconnect.bind(this, options))
     this.socket.send('nuclear_connect', options)
+
 
     return () => {
       this.socket.send('nuclear_disconnect')

--- a/src/server/nuclearnet/direct_nuclearnet_client.ts
+++ b/src/server/nuclearnet/direct_nuclearnet_client.ts
@@ -1,6 +1,7 @@
 import { NUClearNet } from 'nuclearnet.js'
 import { NUClearNetOptions } from 'nuclearnet.js'
 import { NUClearNetSend } from 'nuclearnet.js'
+import { NUClearNetPeer } from 'nuclearnet.js'
 import { NUClearPacketListener } from '../../shared/nuclearnet/nuclearnet_client'
 import { NUClearEventListener } from '../../shared/nuclearnet/nuclearnet_client'
 import { NUClearNetClient } from '../../shared/nuclearnet/nuclearnet_client'

--- a/src/server/nuclearnet/fake_nuclearnet_client.ts
+++ b/src/server/nuclearnet/fake_nuclearnet_client.ts
@@ -36,9 +36,9 @@ export class FakeNUClearNetClient implements NUClearNetClient {
   public connect(options: NUClearNetOptions): () => void {
     this.peer = {
       name: options.name,
-      // Address and port are not used for anything yet, dummy values used.
-      address: 'fake_address',
-      port: NaN,
+      address: '127.0.0.1',
+      // TODO (Annable): Inject a random function.
+      port: Math.floor(Math.random() * (65536 - 1024) + 1024),
     }
     this.connected = true
     const disconnect = this.server.connect(this)

--- a/src/tests/networking_integration.tests.ts
+++ b/src/tests/networking_integration.tests.ts
@@ -1,3 +1,4 @@
+import { AppModel } from '../client/components/app/model'
 import { MessageTypePath } from '../client/network/message_type_names'
 import { Network } from '../client/network/network'
 import { NUsightNetwork } from '../client/network/nusight_network'
@@ -11,6 +12,7 @@ import { SensorDataSimulator } from '../simulators/sensor_data_simulator'
 import Sensors = message.input.Sensors
 import VisionObject = message.vision.VisionObject
 import Overview = message.support.nubugger.Overview
+import { AppNetwork } from '../client/components/app/network'
 
 describe('Networking Integration', () => {
   let nuclearnetServer: FakeNUClearNetServer
@@ -42,9 +44,12 @@ describe('Networking Integration', () => {
   })
 
   function createNUsightNetwork() {
+    const appModel = AppModel.of()
     const nuclearnetClient = new FakeNUClearNetClient(nuclearnetServer)
     const messageTypePath = new MessageTypePath()
-    return new NUsightNetwork(nuclearnetClient, messageTypePath)
+    const nusightNetwork =  new NUsightNetwork(nuclearnetClient, appModel, messageTypePath)
+    AppNetwork.of(nusightNetwork, appModel)
+    return nusightNetwork
   }
 
   describe('a single networked component', () => {
@@ -60,7 +65,7 @@ describe('Networking Integration', () => {
 
       virtualRobots.simulate()
 
-      expect(onSensors).toHaveBeenCalledWith(expect.any(Sensors))
+      expect(onSensors).toHaveBeenCalledWith(expect.objectContaining({ name: 'Robot #1' }), expect.any(Sensors))
       expect(onSensors).toHaveBeenCalledTimes(1)
     })
 
@@ -89,7 +94,7 @@ describe('Networking Integration', () => {
       virtualRobots.simulate()
 
       expect(onSensors1).not.toHaveBeenCalled()
-      expect(onSensors2).toHaveBeenCalledWith(expect.any(Sensors))
+      expect(onSensors2).toHaveBeenCalledWith(expect.objectContaining({ name: 'Robot #1' }), expect.any(Sensors))
     })
   })
 
@@ -110,7 +115,7 @@ describe('Networking Integration', () => {
 
       virtualRobots.simulate()
 
-      expect(onSensors).toHaveBeenCalledWith(expect.any(Sensors))
+      expect(onSensors).toHaveBeenCalledWith(expect.objectContaining({ name: 'Robot #1' }), expect.any(Sensors))
     })
 
     it('handles multiple sessions simutaneously', () => {
@@ -126,8 +131,8 @@ describe('Networking Integration', () => {
 
       virtualRobots.simulate()
 
-      expect(onSensors1).toHaveBeenCalledWith(expect.any(Sensors))
-      expect(onSensors2).toHaveBeenCalledWith(expect.any(Sensors))
+      expect(onSensors1).toHaveBeenCalledWith(expect.objectContaining({ name: 'Robot #1' }), expect.any(Sensors))
+      expect(onSensors2).toHaveBeenCalledWith(expect.objectContaining({ name: 'Robot #1' }), expect.any(Sensors))
     })
   })
 


### PR DESCRIPTION
This PR adds full networking support for robots. That is to say, newly connected robots will automatically show up in the robot selector as well as in the localisation display.

Looks/works better with #75 + throttling though.