### PR TITLE
Update port on reconnect

### DIFF
--- a/src/client/components/app/network.ts
+++ b/src/client/components/app/network.ts
@@ -25,7 +25,7 @@ export class AppNetwork {
 
     if (robot) {
       robot.connected = true
-      // Port changes per connection
+      // Keep this in sync, since the port will likely change per connection.
       robot.port = peer.port
     } else {
       this.model.robots.push(RobotModel.of({

--- a/src/client/components/app/network.ts
+++ b/src/client/components/app/network.ts
@@ -25,6 +25,8 @@ export class AppNetwork {
 
     if (robot) {
       robot.connected = true
+      // Port changes per connection
+      robot.port = peer.port
     } else {
       this.model.robots.push(RobotModel.of({
         name: peer.name,


### PR DESCRIPTION
Without this fix, robots who reconnect would stop responding to messages since their port changed and wasn't updated.