### PR TITLE
Add network throttling

### DIFF
--- a/src/client/nuclearnet/tests/web_socket_proxy_nuclearnet_client.tests.ts
+++ b/src/client/nuclearnet/tests/web_socket_proxy_nuclearnet_client.tests.ts
@@ -60,7 +60,7 @@ describe('WebSocketProxyNUClearNetClient', () => {
     it('forwards generic event add listener requests to socket', () => {
       const cb = jest.fn()
       client.on('foo', cb)
-      expect(mockWebSocket.on).toHaveBeenCalledWith('foo', cb)
+      expect(mockWebSocket.on).toHaveBeenCalledWith('foo', expect.any(Function))
       expect(mockWebSocket.send).toHaveBeenCalledWith('listen', 'foo', '0')
     })
 
@@ -78,7 +78,7 @@ describe('WebSocketProxyNUClearNetClient', () => {
       const cb = jest.fn()
       const off = client.on('foo', cb)
       off()
-      expect(mockWebSocket.off).toHaveBeenCalledWith('foo', cb)
+      expect(mockWebSocket.off).toHaveBeenCalledWith('foo', expect.any(Function))
       expect(mockWebSocket.send).toHaveBeenCalledWith('unlisten', '0')
     })
 

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -50,7 +50,7 @@ server.listen(port, () => {
 if (withSimulators) {
   const virtualRobots = VirtualRobots.of({
     fakeNetworking: true,
-    numRobots: 1,
+    numRobots: 3,
     simulators: [
       SensorDataSimulator.of(),
     ],

--- a/src/server/prod.ts
+++ b/src/server/prod.ts
@@ -32,7 +32,7 @@ server.listen(port, () => {
 if (withSimulators) {
   const virtualRobots = VirtualRobots.of({
     fakeNetworking: true,
-    numRobots: 1,
+    numRobots: 3,
     simulators: [
       SensorDataSimulator.of(),
     ],

--- a/src/simulators/simulate.ts
+++ b/src/simulators/simulate.ts
@@ -9,7 +9,7 @@ function main() {
   const simulators = getSimulators(args)
   const virtualRobots = VirtualRobots.of({
     fakeNetworking: false,
-    numRobots: 1,
+    numRobots: 6,
     simulators,
   })
   virtualRobots.simulateWithFrequency(60)


### PR DESCRIPTION
- Throttles unreliable packets so that we do not overwhelm the client with traffic.
- Sits between `WebSocketProxyNUClearNetServer` and `WebSocketProxyNUClearNetClient`.
- The limit is per-event, such that no particular event should be starved more than any other.
- The limit is per-robot, such that no robot is starved more than any other.