### PR TITLE
Upgrade NUClearNet.js to 1.2.0

### DIFF
--- a/declarations/xxhashjs.d.ts
+++ b/declarations/xxhashjs.d.ts
@@ -1,0 +1,9 @@
+declare module 'xxhashjs' {
+  type XXHashJS = {
+    h32(data: string, seed: number): XXHashJS
+    h64(data: string, seed: number): XXHashJS
+    toString(radix: number): string
+  }
+  const value: XXHashJS
+  export = value
+}

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "minimist": "^1.2.0",
     "mobx": "^3.2.0",
     "mobx-react": "^4.2.2",
-    "nuclearnet.js": "^1.1.0",
+    "nuclearnet.js": "^1.2.0",
     "protobufjs": "^6.7.3",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
@@ -103,6 +103,7 @@
     "serve-favicon": "^2.4.3",
     "socket.io": "^1.7.3",
     "socket.io-client": "^1.7.3",
-    "three": "^0.84.0"
+    "three": "^0.84.0",
+    "xxhashjs": "^0.2.1"
   }
 }

--- a/src/server/nuclearnet/fake_nuclearnet_server.ts
+++ b/src/server/nuclearnet/fake_nuclearnet_server.ts
@@ -2,6 +2,7 @@ import * as EventEmitter from 'events'
 import { NUClearNetSend } from 'nuclearnet.js'
 import { createSingletonFactory } from '../../shared/base/create_singleton_factory'
 import { FakeNUClearNetClient } from './fake_nuclearnet_client'
+import * as XXH from 'xxhashjs'
 
 /**
  * A fake in-memory NUClearNet 'server' which routes messages between each FakeNUClearNetClient.
@@ -59,6 +60,8 @@ export class FakeNUClearNetServer {
     if (typeof opts.type === 'string') {
       const packet = {
         peer: client.peer,
+        type: opts.type,
+        hash: this.hash(opts.type),
         payload: opts.payload,
         reliable: !!opts.reliable,
       }
@@ -75,5 +78,10 @@ export class FakeNUClearNetServer {
         client.fakePacket(opts.type, packet)
       }
     }
+  }
+
+  private hash(input: string): Buffer {
+    const hashString: string = XXH.h64(input, 0x4e55436c).toString(16)
+    return Buffer.from((hashString.match(/../g) as string[]).reverse().join(''), 'hex')
   }
 }

--- a/src/server/nuclearnet/fake_nuclearnet_server.ts
+++ b/src/server/nuclearnet/fake_nuclearnet_server.ts
@@ -81,6 +81,8 @@ export class FakeNUClearNetServer {
   }
 
   private hash(input: string): Buffer {
+    // Matches hashing implementation from NUClearNet
+    // See https://goo.gl/6NDPo2
     const hashString: string = XXH.h64(input, 0x4e55436c).toString(16)
     return Buffer.from((hashString.match(/../g) as string[]).reverse().join(''), 'hex')
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4475,9 +4475,9 @@ nth-check@~1.0.1:
   dependencies:
     boolbase "~1.0.0"
 
-nuclearnet.js@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nuclearnet.js/-/nuclearnet.js-1.1.0.tgz#81338075d33c8c900f84326838f5400ce1475fb6"
+nuclearnet.js@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/nuclearnet.js/-/nuclearnet.js-1.2.0.tgz#a26c83d7495974c87dff1817a4eade8d8e012abe"
   dependencies:
     bindings "^1.2.1"
     nan "^2.0.0"


### PR DESCRIPTION
Uses [`xxhashjs`](https://github.com/pierrec/js-xxhash) to produce identical hash codes to NUClearNet.

Should be able to technically record virtual robots with this.