### PR TITLE
Use webworkers to decode protocol buffers from the network

### DIFF
--- a/declarations/worker-loader.d.ts
+++ b/declarations/worker-loader.d.ts
@@ -1,0 +1,4 @@
+declare module '*.worker.ts' {
+  const content: any
+  export = content
+}

--- a/declarations/worker-loader.d.ts
+++ b/declarations/worker-loader.d.ts
@@ -1,4 +1,5 @@
 declare module '*.worker.ts' {
-  const content: any
+  type WorkerLoader = new() => any
+  const content: WorkerLoader
   export = content
 }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "webpack": "^2.2.1",
     "webpack-dev-middleware": "^1.11.0",
     "webpack-dev-server": "^2.5.1",
-    "webpack-hot-middleware": "^2.18.2"
+    "webpack-hot-middleware": "^2.18.2",
+    "worker-loader": "^0.8.1"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/src/client/network/decode.worker.ts
+++ b/src/client/network/decode.worker.ts
@@ -1,5 +1,22 @@
-import { MessageTypePath } from './message_type_names'
+import { message } from '../../shared/proto/messages'
+
+const HEADER_SIZE = 9
 
 addEventListener('message', (e: MessageEvent) => {
-  postMessage({ 'token': 'Hello main thread!!' })
+  const token = e.data.token
+  const type = e.data.type.split('.')
+  const payload = e.data.payload
+
+  // Using our message type access the appropriate decoder
+  let decoder: any = message
+  for (let i = 1; i < type.length; ++i) {
+    decoder = decoder[type[i]]
+  }
+
+  // Remove NUsight header for decoding by protobufjs
+  const buffer = new Uint8Array(payload).slice(HEADER_SIZE)
+  const output = decoder.decode(buffer)
+
+  // Send back our decoded data!
+  postMessage({ 'token': token, 'output': output })
 })

--- a/src/client/network/decode.worker.ts
+++ b/src/client/network/decode.worker.ts
@@ -1,5 +1,5 @@
 import { MessageTypePath } from './message_type_names'
 
-self.addEventListener('message', (e: MessageEvent) => {
-  self.postMessage({ 'token': 'Hello main thread!!' })
+addEventListener('message', (e: MessageEvent) => {
+  postMessage({ 'token': 'Hello main thread!!' })
 })

--- a/src/client/network/decode.worker.ts
+++ b/src/client/network/decode.worker.ts
@@ -1,0 +1,5 @@
+import { MessageTypePath } from './message_type_names'
+
+self.addEventListener('message', (e: MessageEvent) => {
+  self.postMessage({ 'token': 'Hello main thread!!' })
+})

--- a/src/client/network/nusight_network.ts
+++ b/src/client/network/nusight_network.ts
@@ -35,11 +35,14 @@ export class MessageDecoder {
     return new MessageDecoder(free, [], messageTypePath, {}, 0)
   }
 
-  public decode<T>(type: MessageType<T>, packet: NUClearNetPacket, cb: (message: T) => void) {
+  public decode<T>(type: MessageType<T>, packet: NUClearNetPacket, cb: (message: T) => void, ack?: (time: number) => void) {
+
+    // Timing so the network knows how fast we can process this data
+    const start = performance.now()
 
     // Small packets aren't worth sending to a web worker just decode them here
-    if (packet.payload.byteLength < 512) {
-      cb(type.decode(packet.payload))
+    if (packet.payload.byteLength < 128) {
+      cb(type.decode(new Uint8Array(packet.payload).slice(9)))
     }
     else {
       // Try to get a free worker to process with
@@ -48,22 +51,31 @@ export class MessageDecoder {
       // If we don't have a free worker but we are reliable, get the (hopefully) least busy one
       worker = worker === undefined ? this.busy.shift() : worker
 
-      // Store our callback with a unique token so we can find it later
-      const token = ++this.tokenSource
-      this.callbacks[token] = cb
+      if (worker === undefined) {
+        throw new Error("The webworker pool has no workers!")
+      }
+      else {
+        // Store our callback with a unique token so we can find it later
+        const token = ++this.tokenSource
+        this.callbacks[token] = cb
 
-      // Execute on the webworker
-      try {
-        worker.postMessage({
-          'type': this.messageTypePath.getPath(type),
-          'token': token,
-          'payload': packet.payload,
-        }, [packet.payload])
-        this.busy.push(worker)
+        // Execute on the webworker
+        try {
+          worker.postMessage({
+            'type': this.messageTypePath.getPath(type),
+            'token': token,
+            'payload': packet.payload,
+          }, [packet.payload])
+          this.busy.push(worker)
+        }
+        catch (e) {
+          this.free.push(worker)
+        }
       }
-      catch (e) {
-        this.free.push(worker)
-      }
+    }
+
+    if (ack) {
+      ack(performance.now() - start)
     }
   }
 
@@ -104,12 +116,16 @@ export class NUsightNetwork {
     return this.nuclearnetClient.connect(opts)
   }
 
-  public onNUClearMessage<T>(messageType: MessageType<T>, cb: MessageCallback<T>) {
+  public onNUClearMessage<T>(messageType: MessageType<T>, cb: MessageCallback<T>, ack?: (time: number) => void) {
+
+    // Subscribe in such a way that we can get the ack command if it exists
     const messageTypeName = this.messageTypePath.getPath(messageType)
     return this.nuclearnetClient.on(`NUsight<${messageTypeName}>`, (packet: NUClearNetPacket) => {
 
       // Pass off to our webworker decoder
       this.decoder.decode<T>(messageType, packet, (message: T) => {
+
+        // Find our robot model and execute our callback
         const robotModel = this.appModel.robots.find(robot => {
           return robot.name === packet.peer.name
             && robot.address === packet.peer.address
@@ -118,7 +134,7 @@ export class NUsightNetwork {
         if (robotModel) {
           cb(robotModel, message)
         }
-      })
+      }, ack)
     })
   }
 

--- a/src/client/network/nusight_network.ts
+++ b/src/client/network/nusight_network.ts
@@ -8,7 +8,7 @@ import { RobotModel } from '../components/robot/model'
 import { AppModel } from '../components/app/model'
 import * as DecodeWorker from './decode.worker'
 
-class MessageDecoder {
+export class MessageDecoder {
   public constructor(private free: Worker[],
                      private busy: Worker[],
                      private callbacks: {[key: string]: (message: any) => void},
@@ -16,8 +16,8 @@ class MessageDecoder {
 
     // Register all our completion handlers
     free.forEach(worker => {
-      worker.onmessage = function(ev: MessageEvent) {
-        console.log(ev)
+      worker.onmessage = (ev: MessageEvent) => {
+        this.onTaskComplete(worker, ev.data[0], ev.data[1])
       }
     })
   }
@@ -96,7 +96,9 @@ export class NUsightNetwork {
       // Pass off to our webworker decoder
       this.decoder.decode<T>(messageTypeName, packet, (message: T) => {
         const robotModel = this.appModel.robots.find(robot => {
-          return robot.name === packet.peer.name && robot.address === packet.peer.address && robot.port === packet.peer.port
+          return robot.name === packet.peer.name
+            && robot.address === packet.peer.address
+            && robot.port === packet.peer.port
         })
         if (robotModel) {
           cb(robotModel, message)

--- a/src/client/network/nusight_network.ts
+++ b/src/client/network/nusight_network.ts
@@ -15,10 +15,10 @@ export class MessageDecoder {
                      private tokenSource : number) {
 
     // Register all our completion handlers
-    free.forEach(worker => {
-      worker.onmessage = (ev: MessageEvent) => {
+    free.forEach((worker) => {
+      worker.addEventListener('message', (ev: MessageEvent) => {
         this.onTaskComplete(worker, ev.data[0], ev.data[1])
-      }
+      })
     })
   }
 
@@ -38,6 +38,7 @@ export class MessageDecoder {
     // If we don't have a free worker but we are reliable, get a busy one
     worker = worker === undefined && packet.reliable ? this.busy.shift() : worker
 
+    // We drop packets if they are unreliable and we are too busy to process them
     if (worker !== undefined) {
       // Store our callback with a unique token so we can find it later
       const token = ++this.tokenSource
@@ -60,7 +61,6 @@ export class MessageDecoder {
 
     // If this worker has finished all its tasks move it to the free list
     if (msg.tasks == 0) {
-      // TODO work out what worker this is
       this.free.push(this.busy.splice(this.busy.indexOf(worker), 1)[0])
     }
   }

--- a/src/client/network/nusight_network.ts
+++ b/src/client/network/nusight_network.ts
@@ -6,7 +6,7 @@ import { WebSocketProxyNUClearNetClient } from '../nuclearnet/web_socket_proxy_n
 import { MessageTypePath } from './message_type_names'
 import { RobotModel } from '../components/robot/model'
 import { AppModel } from '../components/app/model'
-import * as DecodeWorker from './decode.worker'
+import * as DecodeWorker from './decode.worker.ts'
 
 export class MessageDecoder {
   public constructor(private free: Worker[],

--- a/src/client/nuclearnet/web_socket_proxy_nuclearnet_client.ts
+++ b/src/client/nuclearnet/web_socket_proxy_nuclearnet_client.ts
@@ -84,10 +84,20 @@ export class WebSocketProxyNUClearNetClient implements NUClearNetClient {
      */
     const requestToken = String(this.nextRequestToken++)
     this.socket.send('listen', event, requestToken)
-    const listener = (packet: NUClearNetPacket, ack?: () => void) => {
-      cb(packet)
-      if (ack) {
-        ack()
+    const listener = (packet: NUClearNetPacket, ack?: (time: number) => void) => {
+
+      // If our listener knows how to use the ack packets hand them over
+      if (cb.length == 2) {
+        (<any>cb)(packet, ack) // TODO HACKS THIS IS BAD DO IT PROPERLY
+      }
+      // Otherwise ack for ourself
+      else if (ack) {
+        const time = performance.now()
+        cb(packet)
+        ack(performance.now() - time)
+      }
+      else {
+        cb(packet)
       }
     }
     this.socket.on(event, listener)

--- a/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
+++ b/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
@@ -163,7 +163,10 @@ class PacketProcessor {
 
   private sendUnreliablePacket(event: string, packet: NUClearNetPacket) {
     // Throttle unreliable packets so that we do not overwhelm the client with traffic.
-    const done = this.enqueue(event)
+    const done = (time: number) => {
+      this.enqueue(event)()
+    }
+
     this.socket.send(event, packet, done)
     this.clock.setTimeout(done, this.timeout)
   }

--- a/src/tests/networking_integration.tests.ts
+++ b/src/tests/networking_integration.tests.ts
@@ -13,6 +13,7 @@ import Sensors = message.input.Sensors
 import VisionObject = message.vision.VisionObject
 import Overview = message.support.nubugger.Overview
 import { AppNetwork } from '../client/components/app/network'
+import { MessageDecoder } from '../client/network/nusight_network'
 
 describe('Networking Integration', () => {
   let nuclearnetServer: FakeNUClearNetServer
@@ -47,7 +48,8 @@ describe('Networking Integration', () => {
     const appModel = AppModel.of()
     const nuclearnetClient = new FakeNUClearNetClient(nuclearnetServer)
     const messageTypePath = new MessageTypePath()
-    const nusightNetwork =  new NUsightNetwork(nuclearnetClient, appModel, messageTypePath)
+    const decoder = MessageDecoder.of()
+    const nusightNetwork =  new NUsightNetwork(nuclearnetClient, appModel, messageTypePath, decoder)
     AppNetwork.of(nusightNetwork, appModel)
     return nusightNetwork
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "lib": [
       "es6",
       "es7",
-      "dom"
+      "dom",
+      "webworker"
     ]
   },
   "include": [

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -43,6 +43,8 @@ export default {
   },
   module: {
     rules: [
+      // webworkers
+      { test: /\.worker.ts$/, use: 'worker-loader' },
       // .ts, .tsx
       {
         test: /\.tsx?$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7097,6 +7097,13 @@ worker-farm@^1.3.1:
     errno ">=0.1.1 <0.2.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
+worker-loader@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-0.8.1.tgz#e8e995331ea34df5bf68296824bfb7f0ad578d43"
+  dependencies:
+    loader-utils "^1.0.2"
+    schema-utils "^0.3.0"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"


### PR DESCRIPTION
A significant amount of processing is done to decode messages from the network.
We can offload this to other threads to keep the main browser responsive and improve performance.