### PR TITLE
Align all robot switch icons to the right

### DIFF
--- a/src/client/components/robot_selector/style.css
+++ b/src/client/components/robot_selector/style.css
@@ -79,6 +79,7 @@
 .robot {
   align-items: center;
   display: flex;
+  justify-content: space-between;
   padding: 1em;
 }
 


### PR DESCRIPTION
See https://github.com/NUbots/NUsight2/issues/79

<img width="255" alt="screen shot 2017-07-15 at 10 12 24 pm" src="https://user-images.githubusercontent.com/132620/28239239-e0bf9202-69aa-11e7-8f12-ed2d88e2bc99.png">
