### PR TITLE
Preserve non-derived models across tabs

### DIFF
--- a/src/client/base/memoize.ts
+++ b/src/client/base/memoize.ts
@@ -1,10 +1,10 @@
 /**
  * Given a function that takes an object A and returns a B, create a new function which memoizes that A -> B transform.
  *
- * i.e. The first time the memoized function called with an A, fn(A) is called and stores A in its internal map. The
- * second time it is called with the same A, it will not call fn(A) and instead just return the B that was created the
- * previous time. Internally the function uses a WeakMap, so the memoized transforms will automatically garbage collect
- * when A no longer exists in memory.
+ * i.e. The first time the memoized function called with an A, it calculates B using fn(A) and stores B in its internal
+ * map. The second time it is called with the same A, it will not call fn(A) and instead just return the B that was
+ * created the previous time. Internally the function uses a WeakMap, so B will be automatically garbage collected when
+ * its corresponding A no longer exists in memory.
  *
  * e.g.
  * const a = { name: 'Foo' }

--- a/src/client/base/memoize.ts
+++ b/src/client/base/memoize.ts
@@ -1,0 +1,26 @@
+/**
+ * Given a function that takes an object A and returns a B, create a new function which memoizes that A -> B transform.
+ *
+ * i.e. The first time the memoized function called with an A, fn(A) is called and stores A in its internal map. The
+ * second time it is called with the same A, it will not call fn(A) and instead just return the B that was created the
+ * previous time. Internally the function uses a WeakMap, so the memoized transforms will automatically garbage collect
+ * when A no longer exists in memory.
+ *
+ * e.g.
+ * const a = { name: 'Foo' }
+ * const fn = a => ({ name: `${a.name}Bar` })
+ * const memoizedFn = memoize(fn)
+ *
+ * fn(a) === f(a) // false
+ * memoizedFn(a) === memoizedFn(a) // true
+ * memoizedFn(a) // { name: `FooBar` }
+ */
+export function memoize<A extends object, B>(fn: (a: A) => B): (a: A) => B {
+  const map = new WeakMap<A, B>()
+  return (a: A) => {
+    if (!map.has(a)) {
+      map.set(a, fn(a))
+    }
+    return map.get(a)!
+  }
+}

--- a/src/client/components/localisation/darwin_robot/model.ts
+++ b/src/client/components/localisation/darwin_robot/model.ts
@@ -1,6 +1,6 @@
 import { observable } from 'mobx'
-import { createTransformer } from 'mobx'
 import { computed } from 'mobx'
+import { memoize } from '../../../base/memoize'
 import { RobotModel } from '../../robot/model'
 import { Vector3 } from '../model'
 import { Quaternion } from '../model'
@@ -18,7 +18,7 @@ export class LocalisationRobotModel {
     Object.assign(this, opts)
   }
 
-  public static of = createTransformer((model: RobotModel): LocalisationRobotModel => {
+  public static of = memoize((model: RobotModel): LocalisationRobotModel => {
     return new LocalisationRobotModel(model, {
       name: model.name,
       rWTt: Vector3.of(),

--- a/src/client/components/localisation/model.ts
+++ b/src/client/components/localisation/model.ts
@@ -4,6 +4,7 @@ import { LocalisationRobotModel } from './darwin_robot/model'
 import { FieldModel } from './field/model'
 import { SkyboxModel } from './skybox/model'
 import { AppModel } from '../app/model'
+import { memoize } from '../../base/memoize'
 
 export class TimeModel {
   @observable public time: number // seconds
@@ -48,7 +49,7 @@ export class LocalisationModel {
     Object.assign(this, opts)
   }
 
-  public static of(appModel: AppModel): LocalisationModel {
+  public static of = memoize((appModel: AppModel): LocalisationModel => {
     return new LocalisationModel(appModel, {
       aspect: 300 / 150,
       field: FieldModel.of(),
@@ -59,7 +60,7 @@ export class LocalisationModel {
       viewMode: ViewMode.FreeCamera,
       time: TimeModel.of(),
     })
-  }
+  })
 
   @computed get robots(): LocalisationRobotModel[] {
     return this.appModel.robots.map(robot => LocalisationRobotModel.of(robot))


### PR DESCRIPTION
Any current use `createTransformer` to transform from `A -> B` where `B` is not 100% derived from `A` will be lost when `B` goes out of scope.

e.g. Take for example, the transformation from `AppModel -> LocalisationModel`. In this case `LocalisationModel` is not 100% derived from `AppModel`, the first call adds a bunch of new properties and we mutate them over time. It is designed to be a long-lived object which should not disappear when switching to another tab, otherwise we will lose all our localisation state. We haven't noticed this behaviour for a few coincidental reasons, but since working on the other tabs this has come up.

This PR introduces a new function, `memoize`, which simply memoizes the mapping between `A` and `B` such that as long as `A` still exists, we will keep its corresponding `B` around. That is to say switching between tabs, we still always get the same `LocalisationModel` back from the same `AppModel`.

Note: We can continue to use `createTransform` in the view models, since they are 100% derived from their inputs and do not suffer from this problem.