### PR TITLE
Update all timers to use seconds

### DIFF
--- a/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
+++ b/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
@@ -127,7 +127,7 @@ class PacketProcessor {
   // The maximum number of packets of a unique type to send before receiving acknowledgements.
   private limit: number
 
-  // The number of milliseconds before giving up on an acknowledge
+  // The number of seconds before giving up on an acknowledge
   private timeout: number
 
   constructor(private socket: WebSocket,
@@ -139,7 +139,7 @@ class PacketProcessor {
   }
 
   public static of(socket: WebSocket) {
-    return new PacketProcessor(socket, NodeSystemClock, { limit: 1, timeout: 5000 })
+    return new PacketProcessor(socket, NodeSystemClock, { limit: 1, timeout: 5 })
   }
 
   public onPacket(event: string, packet: NUClearNetPacket) {

--- a/src/server/time/clock.ts
+++ b/src/server/time/clock.ts
@@ -1,6 +1,7 @@
 export interface Clock {
   now(): number
-  setTimeout(cb: (...args: any[]) => void, ms: number): () => void
-  setInterval(cb: (...args: any[]) => void, ms: number): () => void
+  performanceNow(): number
+  setTimeout(cb: (...args: any[]) => void, seconds: number): () => void
+  setInterval(cb: (...args: any[]) => void, seconds: number): () => void
   setImmediate(cb: (...args: any[]) => void): () => void
 }

--- a/src/server/time/node_clock.ts
+++ b/src/server/time/node_clock.ts
@@ -2,13 +2,13 @@ import { Clock } from './clock'
 
 export type CancelTimer = () => void
 
-function setTimeout(cb: (...args: any[]) => void, ms: number): CancelTimer {
-  const handle = global.setTimeout(cb, ms)
+function setTimeout(cb: (...args: any[]) => void, seconds: number): CancelTimer {
+  const handle = global.setTimeout(cb, seconds * 1e3)
   return global.clearTimeout.bind(null, handle)
 }
 
-function setInterval(cb: (...args: any[]) => void, ms: number): CancelTimer {
-  const handle = global.setInterval(cb, ms)
+function setInterval(cb: (...args: any[]) => void, seconds: number): CancelTimer {
+  const handle = global.setInterval(cb, seconds * 1e3)
   return global.clearInterval.bind(null, handle)
 }
 
@@ -17,8 +17,15 @@ function setImmediate(cb: (...args: any[]) => void): CancelTimer {
   return global.clearImmediate.bind(null, handle)
 }
 
+function performanceNow() {
+  const t = process.hrtime()
+  return t[0] + t[1] * 1e-9
+}
+
+
 export const NodeSystemClock: Clock = {
-  now: () => Date.now(),
+  now: () => Date.now() * 1e-3,
+  performanceNow,
   setTimeout,
   setInterval,
   setImmediate,

--- a/src/simulators/sensor_data_simulator.ts
+++ b/src/simulators/sensor_data_simulator.ts
@@ -16,10 +16,10 @@ export class SensorDataSimulator implements Simulator {
     const messageType = 'message.input.Sensors'
 
     // Simulate a walk
-    const t = time * 5E-3 + index
+    const t = time * 5 + index
 
-    const angle = index * (2 * Math.PI) / numRobots + time / 4E4
-    const distance = Math.cos(time / 1E3 + 4 * index) * 0.3 + 1
+    const angle = index * (2 * Math.PI) / numRobots + time / 40
+    const distance = Math.cos(time + 4 * index) * 0.3 + 1
     const x = distance * Math.cos(angle)
     const y = distance * Math.sin(angle)
     const heading = -angle - Math.PI / 2

--- a/src/simulators/virtual_robot.ts
+++ b/src/simulators/virtual_robot.ts
@@ -32,7 +32,7 @@ export class VirtualRobot {
   public simulateWithFrequency(frequency: number, index: number, numRobots: number) {
     const disconnect = this.connect()
 
-    const period = 1000 / frequency
+    const period = 1 / frequency
     const cancelLoop = this.clock.setInterval(() => this.simulate(index, numRobots), period)
 
     return () => {


### PR DESCRIPTION
In the interest of keeping all our units consistently using the SI standard and reducing the number of conversions throughout the code, this PR updates all timers to operate in seconds.