### PR TITLE
Add fake clock

### DIFF
--- a/src/server/time/fake_clock.ts
+++ b/src/server/time/fake_clock.ts
@@ -1,0 +1,136 @@
+import { Clock } from './clock'
+
+type Task = {
+  id: number,
+  nextTime: number,
+  period?: number,
+  fn(): void,
+}
+
+export class FakeClock implements Clock {
+  private nextId: number
+  private time: number
+  private tasks: Task[]
+
+  constructor() {
+    this.nextId = 0
+    this.time = 0
+    this.tasks = []
+  }
+
+  public static of() {
+    return new FakeClock()
+  }
+
+  public now(): number {
+    return this.time
+  }
+
+  public performanceNow(): number {
+    return this.time
+  }
+
+  public setTimeout(fn: () => void, seconds: number): () => void {
+    const id = this.nextId++
+    this.addTask({ id, nextTime: this.now() + seconds, fn })
+    return () => this.removeTask(id)
+  }
+
+  public setInterval(fn: () => void, seconds: number): () => void {
+    const id = this.nextId++
+    this.addTask({ id, nextTime: this.now() + seconds, period: seconds, fn })
+    return () => this.removeTask(id)
+  }
+
+  public setImmediate(fn: () => void): () => void {
+    const id = this.nextId++
+    this.addTask({ id, nextTime: this.now() + Number.MIN_VALUE, fn })
+    return () => this.removeTask(id)
+  }
+
+  public tick(delta: number = 1) {
+    const newTime = this.now() + delta
+
+    while (this.tasks.length > 0 && this.tasks[0].nextTime <= newTime) {
+      const task = this.tasks[0]
+      this.consumeTask(task)
+    }
+
+    this.time = newTime
+  }
+
+  public runAllTimers() {
+    const limit = 1000
+    let i = 0
+
+    while (this.tasks.length > 0) {
+      if (i > limit) {
+        throw new Error(`Exceeded clock task limit of ${limit}, possibly caused by a infinite task loop?`)
+      }
+      const task = this.tasks[0]
+      this.consumeTask(task)
+      i++
+    }
+  }
+
+  public runOnlyPendingTimers() {
+    const limit = 1000
+    let i = 0
+
+    const lastTastTime = this.tasks.length > 0 && this.tasks[this.tasks.length - 1].nextTime
+
+    while (this.tasks.length > 0 && this.tasks[0].nextTime <= lastTastTime) {
+      if (i > limit) {
+        throw new Error(`Exceeded clock task limit of ${limit}, possibly caused by a infinite task loop?`)
+      }
+      const task = this.tasks[0]
+      this.consumeTask(task)
+      i++
+    }
+  }
+
+  public runTimersToTime(time: number) {
+    const limit = 1000
+    let i = 0
+
+    while (this.tasks.length > 0 && this.tasks[0].nextTime <= time) {
+      if (i > limit) {
+        throw new Error(`Exceeded clock task limit of ${limit}, possibly caused by a infinite task loop?`)
+      }
+      const task = this.tasks[0]
+      this.consumeTask(task)
+      i++
+    }
+  }
+
+  private addTask(task: Task) {
+    this.tasks.push(task)
+    this.sortTasks()
+  }
+
+  private sortTasks() {
+    this.tasks.sort((t1, t2) => {
+      return t1.nextTime - t2.nextTime
+    })
+  }
+
+  private consumeTask(task: Task) {
+    this.time = task.nextTime
+    if (task.period != null) {
+      task.nextTime += task.period
+      this.sortTasks()
+    } else {
+      this.tasks.shift()
+    }
+    task.fn()
+  }
+
+  private removeTask(taskId: number) {
+    for (let i = 0; i < this.tasks.length; i++) {
+      if (this.tasks[i].id == taskId) {
+        this.tasks.splice(i, 1)
+        break
+      }
+    }
+  }
+}

--- a/src/server/time/tests/fake_clock.tests.ts
+++ b/src/server/time/tests/fake_clock.tests.ts
@@ -27,27 +27,27 @@ describe('FakeClock', () => {
   })
 
   describe('#setTimeout', () => {
-    it('does not call synchronously', () => {
+    it('does not invoke callback synchronously', () => {
       const spy = jest.fn()
       clock.setTimeout(spy, 0)
       expect(spy).not.toHaveBeenCalled()
     })
 
-    it('does not call callback before expected time', () => {
+    it('does not invoke callback before expected time', () => {
       const spy = jest.fn()
       clock.setTimeout(spy, 2)
       clock.tick(1)
       expect(spy).not.toHaveBeenCalled()
     })
 
-    it('calls callback at expected time', () => {
+    it('invokes callback at expected time', () => {
       const spy = jest.fn()
       clock.setTimeout(spy, 2)
       clock.tick(2)
       expect(spy).toHaveBeenCalled()
     })
 
-    it('can be cancelled', () => {
+    it('does not invoke callback when cancelled', () => {
       const spy = jest.fn()
       const cancel = clock.setTimeout(spy, 2)
 
@@ -58,13 +58,13 @@ describe('FakeClock', () => {
   })
 
   describe('#setInterval', () => {
-    it('does not call synchronously', () => {
+    it('does not invoke callback synchronously', () => {
       const spy = jest.fn()
       clock.setInterval(spy, 2)
       expect(spy).not.toHaveBeenCalled()
     })
 
-    it('calls callback regularly at expected times', () => {
+    it('invokes callback regularly at expected times', () => {
       const spy = jest.fn()
       clock.setInterval(spy, 2)
 
@@ -78,7 +78,7 @@ describe('FakeClock', () => {
       expect(spy).toHaveBeenCalledTimes(2)
     })
 
-    it('can be cancelled', () => {
+    it('does not invoke callback when cancelled', () => {
       const spy = jest.fn()
       const cancel = clock.setInterval(spy, 2)
 
@@ -89,13 +89,13 @@ describe('FakeClock', () => {
   })
 
   describe('#setImmediate', () => {
-    it('does not call synchronously', () => {
+    it('does not invoke callback synchronously', () => {
       const spy = jest.fn()
       clock.setImmediate(spy)
       expect(spy).not.toHaveBeenCalled()
     })
 
-    it('calls after at least any tick', () => {
+    it('invokes callback after any tick', () => {
       const spy = jest.fn()
       clock.setImmediate(spy)
 
@@ -103,7 +103,7 @@ describe('FakeClock', () => {
       expect(spy).toHaveBeenCalled()
     })
 
-    it('can be cancelled', () => {
+    it('does not invoke callback when cancelled', () => {
       const spy = jest.fn()
       const cancel = clock.setImmediate(spy)
 
@@ -114,7 +114,7 @@ describe('FakeClock', () => {
   })
 
   describe('#runAllTimers', () => {
-    it('runs all timers, including new ones that are created from the call', () => {
+    it('invokes all scheduled timers', () => {
       const spy1 = jest.fn()
       const spy2 = jest.fn()
       const spy3 = jest.fn()
@@ -129,7 +129,7 @@ describe('FakeClock', () => {
       expect(spy3).toHaveBeenCalled()
     })
 
-    it('runs all timers, including new ones that are created from the call', () => {
+    it('invokes all scheduled timers, including any new timers that were scheduled from running them', () => {
       const spy1 = jest.fn()
       const spy2 = jest.fn()
 
@@ -153,7 +153,7 @@ describe('FakeClock', () => {
   })
 
   describe('#runOnlyPendingTimers', () => {
-    it('runs all pending timers', () => {
+    it('invokes all scheduled timers', () => {
       const spy1 = jest.fn()
       const spy2 = jest.fn()
       const spy3 = jest.fn()
@@ -168,7 +168,7 @@ describe('FakeClock', () => {
       expect(spy3).toHaveBeenCalled()
     })
 
-    it('runs all timers, excluding new ones that are created from the call', () => {
+    it('invokes all scheduled timers, excluding any new timers that were scheduled from running them', () => {
       const spy1 = jest.fn()
       const spy2 = jest.fn()
       const spy3 = jest.fn()
@@ -196,7 +196,7 @@ describe('FakeClock', () => {
   })
 
   describe('#runTimersToTime', () => {
-    it('runs all timers before given time', () => {
+    it('invokes all scheduled timers before the given time', () => {
       const spy1 = jest.fn()
       const spy2 = jest.fn()
       const spy3 = jest.fn()

--- a/src/server/time/tests/fake_clock.tests.ts
+++ b/src/server/time/tests/fake_clock.tests.ts
@@ -1,0 +1,203 @@
+import { FakeClock } from '../fake_clock'
+
+describe('FakeClock', () => {
+  let clock: FakeClock
+
+  beforeEach(() => {
+    clock = new FakeClock()
+  })
+
+  describe('#setTimeout', () => {
+    it('does not call synchronously', () => {
+      const spy = jest.fn()
+      clock.setTimeout(spy, 0)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('does not call callback before expected time', () => {
+      const spy = jest.fn()
+      clock.setTimeout(spy, 2)
+      clock.tick(1)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('calls callback at expected time', () => {
+      const spy = jest.fn()
+      clock.setTimeout(spy, 2)
+      clock.tick(2)
+      expect(spy).toHaveBeenCalled()
+    })
+
+    it('can be cancelled', () => {
+      const spy = jest.fn()
+      const cancel = clock.setTimeout(spy, 2)
+
+      cancel()
+      clock.tick(100)
+      expect(spy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('#setInterval', () => {
+    it('does not call synchronously', () => {
+      const spy = jest.fn()
+      clock.setInterval(spy, 2)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('calls callback regularly at expected times', () => {
+      const spy = jest.fn()
+      clock.setInterval(spy, 2)
+
+      clock.tick(2)
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      clock.tick(1) // Tick half way, should not call yet.
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      clock.tick(1) // Tick all the way, should be called now.
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('can be cancelled', () => {
+      const spy = jest.fn()
+      const cancel = clock.setInterval(spy, 2)
+
+      cancel()
+      clock.tick(100)
+      expect(spy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('#setImmediate', () => {
+    it('does not call synchronously', () => {
+      const spy = jest.fn()
+      clock.setImmediate(spy)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('calls after at least any tick', () => {
+      const spy = jest.fn()
+      clock.setImmediate(spy)
+
+      clock.tick(0.1)
+      expect(spy).toHaveBeenCalled()
+    })
+
+    it('can be cancelled', () => {
+      const spy = jest.fn()
+      const cancel = clock.setImmediate(spy)
+
+      cancel()
+      clock.tick(100)
+      expect(spy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('#runAllTimers', () => {
+    it('runs all timers, including new ones that are created from the call', () => {
+      const spy1 = jest.fn()
+      const spy2 = jest.fn()
+      const spy3 = jest.fn()
+
+      clock.setTimeout(spy1, 1)
+      clock.setTimeout(spy2, 10)
+      clock.setTimeout(spy3, 100)
+      clock.runAllTimers()
+
+      expect(spy1).toHaveBeenCalled()
+      expect(spy2).toHaveBeenCalled()
+      expect(spy3).toHaveBeenCalled()
+    })
+
+    it('runs all timers, including new ones that are created from the call', () => {
+      const spy1 = jest.fn()
+      const spy2 = jest.fn()
+
+      clock.setTimeout(() => {
+        spy1()
+        clock.setTimeout(spy2, 1)
+      }, 1)
+
+      clock.runAllTimers()
+      expect(spy1).toHaveBeenCalled()
+      expect(spy2).toHaveBeenCalled()
+    })
+
+    it('throws an exception where there are too many scheduled tasks', () => {
+      for (let i = 0; i < 2000; i++) {
+        clock.setTimeout(jest.fn(), 1)
+      }
+
+      expect(() => clock.runAllTimers()).toThrow(/Exceeded clock task limit/)
+    })
+  })
+
+  describe('#runOnlyPendingTimers', () => {
+    it('runs all pending timers', () => {
+      const spy1 = jest.fn()
+      const spy2 = jest.fn()
+      const spy3 = jest.fn()
+
+      clock.setTimeout(spy1, 1)
+      clock.setTimeout(spy2, 10)
+      clock.setTimeout(spy3, 100)
+
+      clock.runOnlyPendingTimers()
+      expect(spy1).toHaveBeenCalled()
+      expect(spy2).toHaveBeenCalled()
+      expect(spy3).toHaveBeenCalled()
+    })
+
+    it('runs all timers, excluding new ones that are created from the call', () => {
+      const spy1 = jest.fn()
+      const spy2 = jest.fn()
+      const spy3 = jest.fn()
+
+      clock.setTimeout(() => {
+        spy1()
+        clock.setTimeout(spy3, 20)
+      }, 10)
+
+      clock.setTimeout(spy2, 10)
+
+      clock.runOnlyPendingTimers()
+      expect(spy1).toHaveBeenCalled()
+      expect(spy2).toHaveBeenCalled()
+      expect(spy3).not.toHaveBeenCalled()
+    })
+
+    it('throws an exception where there are too many scheduled tasks', () => {
+      for (let i = 0; i < 2000; i++) {
+        clock.setTimeout(jest.fn(), 1)
+      }
+
+      expect(() => clock.runOnlyPendingTimers()).toThrow(/Exceeded clock task limit/)
+    })
+  })
+
+  describe('#runTimersToTime', () => {
+    it('runs all timers before given time', () => {
+      const spy1 = jest.fn()
+      const spy2 = jest.fn()
+      const spy3 = jest.fn()
+
+      clock.setTimeout(spy1, 1)
+      clock.setTimeout(spy2, 10)
+      clock.setTimeout(spy3, 100)
+
+      clock.runTimersToTime(50)
+      expect(spy1).toHaveBeenCalled()
+      expect(spy2).toHaveBeenCalled()
+      expect(spy3).not.toHaveBeenCalled()
+    })
+
+    it('throws an exception where there are too many scheduled tasks', () => {
+      for (let i = 0; i < 2000; i++) {
+        clock.setTimeout(jest.fn(), 1)
+      }
+
+      expect(() => clock.runTimersToTime(2000)).toThrow(/Exceeded clock task limit/)
+    })
+  })
+})

--- a/src/server/time/tests/fake_clock.tests.ts
+++ b/src/server/time/tests/fake_clock.tests.ts
@@ -7,6 +7,25 @@ describe('FakeClock', () => {
     clock = new FakeClock()
   })
 
+  describe('#tick', () => {
+    it('moves forward time', () => {
+      expect(clock.now()).toEqual(0)
+      expect(clock.performanceNow()).toEqual(0)
+
+      clock.tick(10)
+      expect(clock.now()).toEqual(10)
+      expect(clock.performanceNow()).toEqual(10)
+
+      clock.tick(10)
+      expect(clock.now()).toEqual(20)
+      expect(clock.performanceNow()).toEqual(20)
+
+      clock.tick(10)
+      expect(clock.now()).toEqual(30)
+      expect(clock.performanceNow()).toEqual(30)
+    })
+  })
+
   describe('#setTimeout', () => {
     it('does not call synchronously', () => {
       const spy = jest.fn()


### PR DESCRIPTION
Add a fake synchronous clock to be used in tests, already using them in the upcoming nbs playback code. This lets you write unit tests for modules that deal with time, without the tests using real time. It implements the `Clock` interface.

API roughly based around jest timers https://facebook.github.io/jest/docs/timer-mocks.html

Featuring:
- `tick(delta: number = 1)` — Move forward time a relative amount.
- `runAllTimers()` — Recursively run all scheduled timers, including any that those timers schedule themselves.
- `runOnlyPendingTimers()` — Run all scheduled timers, excluding any additional scheduled timers.
- `runTimersToTime(time: number)` — Move forward time to an absolute point.

If you're wondering why not use jest timers? They are somewhat incompatible with dependency injection. They essentially monkey patch the global variable. These will be injected directly into modules that use timers.