### PR TITLE
Upgrade NUClearNet.js to 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "minimist": "^1.2.0",
     "mobx": "^3.2.0",
     "mobx-react": "^4.2.2",
-    "nuclearnet.js": "^1.2.0",
+    "nuclearnet.js": "^1.4.2",
     "protobufjs": "^6.7.3",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",

--- a/src/client/nuclearnet/web_socket_proxy_nuclearnet_client.ts
+++ b/src/client/nuclearnet/web_socket_proxy_nuclearnet_client.ts
@@ -1,11 +1,10 @@
 import { NUClearNetOptions } from 'nuclearnet.js'
 import { NUClearNetSend } from 'nuclearnet.js'
+import { NUClearNetPacket } from 'nuclearnet.js'
 import { NUClearPacketListener } from '../../shared/nuclearnet/nuclearnet_client'
 import { NUClearEventListener } from '../../shared/nuclearnet/nuclearnet_client'
 import { NUClearNetClient } from '../../shared/nuclearnet/nuclearnet_client'
 import { WebSocketClient } from './web_socket_client'
-import SocketIOSocket = SocketIOClient.Socket
-import { NUClearNetPacket } from 'nuclearnet.js'
 
 type PacketListener = (packet: NUClearNetPacket, ack?: () => void) => void
 
@@ -109,6 +108,10 @@ export class WebSocketProxyNUClearNetClient implements NUClearNetClient {
         packetListeners.delete(packetListener)
       }
     }
+  }
+
+  public onPacket(cb: NUClearPacketListener): () => void {
+    return this.on('nuclear_packet', cb)
   }
 
   public send(options: NUClearNetSend): void {

--- a/src/server/nuclearnet/direct_nuclearnet_client.ts
+++ b/src/server/nuclearnet/direct_nuclearnet_client.ts
@@ -38,6 +38,10 @@ export class DirectNUClearNetClient implements NUClearNetClient {
     return () => this.nuclearNetwork.removeListener(event, cb)
   }
 
+  public onPacket(cb: NUClearPacketListener): () => void {
+    return this.on('nuclear_packet', cb)
+  }
+
   public send(options: NUClearNetSend): void {
     this.nuclearNetwork.send(options)
   }

--- a/src/server/nuclearnet/fake_nuclearnet_server.ts
+++ b/src/server/nuclearnet/fake_nuclearnet_server.ts
@@ -1,14 +1,14 @@
 import * as EventEmitter from 'events'
 import { NUClearNetSend } from 'nuclearnet.js'
+import * as XXH from 'xxhashjs'
 import { createSingletonFactory } from '../../shared/base/create_singleton_factory'
 import { FakeNUClearNetClient } from './fake_nuclearnet_client'
-import * as XXH from 'xxhashjs'
 
 /**
  * A fake in-memory NUClearNet 'server' which routes messages between each FakeNUClearNetClient.
  *
  * All messages are 'reliable' in that nothing is intentially dropped.
- * Targetted messages are supported.
+ * Targeted messages are supported.
  */
 export class FakeNUClearNetServer {
   private events: EventEmitter
@@ -57,33 +57,33 @@ export class FakeNUClearNetServer {
   }
 
   public send(client: FakeNUClearNetClient, opts: NUClearNetSend) {
-    if (typeof opts.type === 'string') {
-      const packet = {
-        peer: client.peer,
-        type: opts.type,
-        hash: this.hash(opts.type),
-        payload: opts.payload,
-        reliable: !!opts.reliable,
-      }
+    const hash: Buffer = typeof opts.type === 'string' ? hashType(opts.type) : opts.type
+    const packet = {
+      peer: client.peer,
+      type: typeof opts.type === 'string' ? opts.type : undefined,
+      hash,
+      payload: opts.payload,
+      reliable: !!opts.reliable,
+    }
 
-      /*
-       * This list intentially includes the sender unless explicitly targeting another peer. This matches the real
-       * NUClearNet behaviour.
-       */
-      const targetClients = opts.target === undefined
-        ? this.clients
-        : this.clients.filter(otherClient => otherClient.peer.name === opts.target)
+    /*
+     * This list intentionally includes the sender unless explicitly targeting another peer. This matches the real
+     * NUClearNet behaviour.
+     */
+    const targetClients = opts.target === undefined
+      ? this.clients
+      : this.clients.filter(otherClient => otherClient.peer.name === opts.target)
 
-      for (const client of targetClients) {
-        client.fakePacket(opts.type, packet)
-      }
+    const hashString = hash.toString('hex')
+    for (const client of targetClients) {
+      client.fakePacket(hashString, packet)
     }
   }
+}
 
-  private hash(input: string): Buffer {
-    // Matches hashing implementation from NUClearNet
-    // See https://goo.gl/6NDPo2
-    const hashString: string = XXH.h64(input, 0x4e55436c).toString(16)
-    return Buffer.from((hashString.match(/../g) as string[]).reverse().join(''), 'hex')
-  }
+export function hashType(type: string): Buffer {
+  // Matches hashing implementation from NUClearNet
+  // See https://goo.gl/6NDPo2
+  const hashString: string = XXH.h64(type, 0x4e55436c).toString(16)
+  return Buffer.from((hashString.match(/../g) as string[]).reverse().join(''), 'hex')
 }

--- a/src/server/nuclearnet/tests/fake_nuclearnet_client.tests.ts
+++ b/src/server/nuclearnet/tests/fake_nuclearnet_client.tests.ts
@@ -142,7 +142,7 @@ describe('FakeNUClearNetClient', () => {
     }))
   })
 
-  it('receives messages sent from other clients', () => {
+  it('receives specific messages sent from other clients', () => {
     bob.connect({ name: 'bob' })
     alice.connect({ name: 'alice' })
     eve.connect({ name: 'eve' })
@@ -167,6 +167,42 @@ describe('FakeNUClearNetClient', () => {
 
     expect(aliceOnSensors).toHaveBeenCalledTimes(1)
     expect(aliceOnSensors).toHaveBeenLastCalledWith(expect.objectContaining({
+      payload,
+      peer: expect.objectContaining({ name: 'eve' }),
+    }))
+
+    expect(eveOnSensors).toHaveBeenCalledTimes(1)
+    expect(eveOnSensors).toHaveBeenLastCalledWith(expect.objectContaining({
+      payload,
+      peer: expect.objectContaining({ name: 'eve' }),
+    }))
+  })
+
+  it('receives general packets sent from other clients', () => {
+    bob.connect({ name: 'bob' })
+    alice.connect({ name: 'alice' })
+    eve.connect({ name: 'eve' })
+
+    const bobOnPacket = jest.fn()
+    bob.onPacket(bobOnPacket)
+
+    const aliceOnPacket = jest.fn()
+    alice.onPacket(aliceOnPacket)
+
+    const eveOnSensors = jest.fn()
+    eve.on('sensors', eveOnSensors)
+
+    const payload = new Buffer(8)
+    eve.send({ type: 'sensors', payload })
+
+    expect(bobOnPacket).toHaveBeenCalledTimes(1)
+    expect(bobOnPacket).toHaveBeenLastCalledWith(expect.objectContaining({
+      payload,
+      peer: expect.objectContaining({ name: 'eve' }),
+    }))
+
+    expect(aliceOnPacket).toHaveBeenCalledTimes(1)
+    expect(aliceOnPacket).toHaveBeenLastCalledWith(expect.objectContaining({
       payload,
       peer: expect.objectContaining({ name: 'eve' }),
     }))

--- a/src/shared/nuclearnet/nuclearnet_client.ts
+++ b/src/shared/nuclearnet/nuclearnet_client.ts
@@ -12,5 +12,6 @@ export interface NUClearNetClient {
   onJoin(cb: NUClearEventListener): () => void
   onLeave(cb: NUClearEventListener): () => void
   on(event: string, cb: NUClearPacketListener): () => void
+  onPacket(cb: NUClearPacketListener): () => void
   send(options: NUClearNetSend): void
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4475,9 +4475,9 @@ nth-check@~1.0.1:
   dependencies:
     boolbase "~1.0.0"
 
-nuclearnet.js@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/nuclearnet.js/-/nuclearnet.js-1.2.0.tgz#a26c83d7495974c87dff1817a4eade8d8e012abe"
+nuclearnet.js@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/nuclearnet.js/-/nuclearnet.js-1.4.2.tgz#9a25ea04ac84d866e92bf1851b1754229c6e173c"
   dependencies:
     bindings "^1.2.1"
     nan "^2.0.0"


### PR DESCRIPTION
Supports new `onPacket` method, upgrades fakes to match.

In order to match the real behaviour, the fakes now need to use real hashes. Previously we were abstracting that away.