### PR TITLE
Fix reconnection bug

### DIFF
--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -24,6 +24,11 @@ const app = express()
 const server = http.createServer(app)
 const sioNetwork = sio(server)
 
+// Initialize socket.io namespace immediately to catch reconnections.
+WebSocketProxyNUClearNetServer.of(WebSocketServer.of(sioNetwork.of('/nuclearnet')), {
+  fakeNetworking: withSimulators,
+})
+
 const devMiddleware = webpackDevMiddleware(compiler, {
   publicPath: '/',
   index: 'index.html',
@@ -60,10 +65,6 @@ function init() {
     })
     virtualRobots.simulateWithFrequency(60)
   }
-
-  WebSocketProxyNUClearNetServer.of(WebSocketServer.of(sioNetwork.of('/nuclearnet')), {
-    fakeNetworking: withSimulators,
-  })
 }
 
 devMiddleware.waitUntilValid(init)


### PR DESCRIPTION
Reconnecting clients were sometimes getting an invalid namespace error from socket.io if you restarted the server.

This was because `sioNetwork.of('/nuclearnet')` was not being called straight away to initialize the namespace. The connection listener also needs to be attached before `server.listen` is called.

This solves both these problems by moving it out of the async `init` function and instead straight after creating the socket.