### PR TITLE
Add timestamp to overview simulator

### DIFF
--- a/src/simulators/overview_simulator.ts
+++ b/src/simulators/overview_simulator.ts
@@ -46,10 +46,11 @@ export class OverviewSimulator implements Simulator {
     const penaltyReasons = getEnumValues<PenaltyReason>(PenaltyReason)
 
     const buffer = Overview.encode({
-      roleName: 'Overview Simulator',
+      timestamp: { seconds: time },
       robotId: index + 1,
-      voltage: this.randomFloat(10, 13),
+      roleName: 'Overview Simulator',
       battery: this.random.float(),
+      voltage: this.randomFloat(10, 13),
       behaviourState: this.random.choice(states),
       robotPosition: new Vector3(robotPosition.x, robotPosition.y, robotAngle),
       robotPositionCovariance: {
@@ -62,13 +63,13 @@ export class OverviewSimulator implements Simulator {
         x: { x: this.random.float(), y: this.random.float() },
         y: { x: this.random.float(), y: this.random.float() },
       },
+      kickTarget: this.figureEight(-t).add(ballPosition),
       gameMode: this.random.choice(modes),
       gamePhase: this.random.choice(phases),
       penaltyReason: this.random.choice(penaltyReasons),
       lastCameraImage: { seconds: this.randomSeconds(time, -5) },
       lastSeenBall: { seconds: this.randomSeconds(time, -30) },
       lastSeenGoal: { seconds: this.randomSeconds(time, -30) },
-      timestamp: { seconds: time },
       walkPathPlan: [
         robotPosition,
         this.randomFieldPosition(),
@@ -76,7 +77,6 @@ export class OverviewSimulator implements Simulator {
         this.randomFieldPosition(),
         ballPosition,
       ],
-      kickTarget: this.figureEight(-t).add(ballPosition),
     }).finish()
 
     const message = { messageType, buffer }

--- a/src/simulators/overview_simulator.ts
+++ b/src/simulators/overview_simulator.ts
@@ -27,7 +27,7 @@ export class OverviewSimulator implements Simulator {
   public simulate(time: number, index: number, numRobots: number): Message[] {
     const messageType = 'message.support.nubugger.Overview'
 
-    const t = time / 10 + index
+    const t = time / 10 - index
 
     const fieldLength = this.field.fieldLength
     const fieldWidth = this.field.fieldWidth

--- a/src/simulators/overview_simulator.ts
+++ b/src/simulators/overview_simulator.ts
@@ -68,6 +68,7 @@ export class OverviewSimulator implements Simulator {
       lastCameraImage: { seconds: this.randomSeconds(time, -5) },
       lastSeenBall: { seconds: this.randomSeconds(time, -30) },
       lastSeenGoal: { seconds: this.randomSeconds(time, -30) },
+      timestamp: { seconds: time },
       walkPathPlan: [
         robotPosition,
         this.randomFieldPosition(),


### PR DESCRIPTION
Fixes the last seen icons in the dashboard.

<img width="436" alt="screen shot 2017-07-26 at 11 00 37 pm" src="https://user-images.githubusercontent.com/132620/28622003-4353210a-7256-11e7-81a8-e5556090e6f6.png">
