### PR TITLE
Replace setImmediate with nextTick

### DIFF
--- a/src/client/time/browser_clock.ts
+++ b/src/client/time/browser_clock.ts
@@ -15,6 +15,8 @@ function setInterval(cb: () => void, seconds: number): CancelTimer {
 }
 
 function nextTick(cb: () => void): void {
+  // Promises are guaranteed to resolve asynchronously. This is a faster alternative to setTimeout(cb, 0).
+  // See https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/
   Promise.resolve().then(cb)
 }
 

--- a/src/client/time/browser_clock.ts
+++ b/src/client/time/browser_clock.ts
@@ -4,22 +4,21 @@ import { Clock } from '../../shared/time/clock'
 const SecondsToMilliseconds = 1e3
 const MillisecondsToSeconds = 1e-3
 
-function setTimeout(cb: (...args: any[]) => void, seconds: number): CancelTimer {
+function setTimeout(cb: () => void, seconds: number): CancelTimer {
   const handle = window.setTimeout(cb, seconds * SecondsToMilliseconds)
   return window.clearTimeout.bind(undefined, handle)
 }
 
-function setInterval(cb: (...args: any[]) => void, seconds: number): CancelTimer {
+function setInterval(cb: () => void, seconds: number): CancelTimer {
   const handle = window.setInterval(cb, seconds * SecondsToMilliseconds)
   return window.clearInterval.bind(undefined, handle)
 }
 
-function setImmediate(cb: (...args: any[]) => void): CancelTimer {
-  const handle = window.setTimeout(cb, 0)
-  return window.clearTimeout.bind(undefined, handle)
+function nextTick(cb: () => void): void {
+  Promise.resolve().then(cb)
 }
 
-function performanceNow() {
+function performanceNow(): number {
   return window.performance.now() * MillisecondsToSeconds
 }
 
@@ -28,5 +27,5 @@ export const BrowserSystemClock: Clock = {
   performanceNow,
   setTimeout,
   setInterval,
-  setImmediate,
+  nextTick,
 }

--- a/src/server/time/node_clock.ts
+++ b/src/server/time/node_clock.ts
@@ -5,22 +5,21 @@ const SecondsToMilliseconds = 1e3
 const MillisecondsToSeconds = 1e-3
 const NanosecondsToSeconds = 1e-9
 
-function setTimeout(cb: (...args: any[]) => void, seconds: number): CancelTimer {
+function setTimeout(cb: () => void, seconds: number): CancelTimer {
   const handle = global.setTimeout(cb, seconds * SecondsToMilliseconds)
   return global.clearTimeout.bind(undefined, handle)
 }
 
-function setInterval(cb: (...args: any[]) => void, seconds: number): CancelTimer {
+function setInterval(cb: () => void, seconds: number): CancelTimer {
   const handle = global.setInterval(cb, seconds * SecondsToMilliseconds)
   return global.clearInterval.bind(undefined, handle)
 }
 
-function setImmediate(cb: (...args: any[]) => void): CancelTimer {
-  const handle = global.setImmediate(cb)
-  return global.clearImmediate.bind(undefined, handle)
+function nextTick(cb: () => void): void {
+  process.nextTick(cb)
 }
 
-function performanceNow() {
+function performanceNow(): number {
   const t = process.hrtime()
   return t[0] + t[1] * NanosecondsToSeconds
 }
@@ -30,5 +29,5 @@ export const NodeSystemClock: Clock = {
   performanceNow,
   setTimeout,
   setInterval,
-  setImmediate,
+  nextTick,
 }

--- a/src/server/time/tests/fake_clock.tests.ts
+++ b/src/server/time/tests/fake_clock.tests.ts
@@ -88,16 +88,16 @@ describe('FakeClock', () => {
     })
   })
 
-  describe('#setImmediate', () => {
+  describe('#nextTick', () => {
     it('does not invoke callback synchronously', () => {
       const spy = jest.fn()
-      clock.setImmediate(spy)
+      clock.nextTick(spy)
       expect(spy).not.toHaveBeenCalled()
     })
 
     it('invokes callback after any tick', () => {
       const spy = jest.fn()
-      clock.setImmediate(spy)
+      clock.nextTick(spy)
 
       clock.tick(0.1)
       expect(spy).toHaveBeenCalled()
@@ -105,7 +105,7 @@ describe('FakeClock', () => {
 
     it('does not invoke callback when cancelled', () => {
       const spy = jest.fn()
-      const cancel = clock.setImmediate(spy)
+      const cancel = clock.nextTick(spy)
 
       cancel()
       clock.tick(100)

--- a/src/shared/time/clock.ts
+++ b/src/shared/time/clock.ts
@@ -1,9 +1,9 @@
 export interface Clock {
   now(): number
   performanceNow(): number
-  setTimeout(cb: (...args: any[]) => void, seconds: number): CancelTimer
-  setInterval(cb: (...args: any[]) => void, seconds: number): CancelTimer
-  setImmediate(cb: (...args: any[]) => void): CancelTimer
+  setTimeout(cb: () => void, seconds: number): CancelTimer
+  setInterval(cb: () => void, seconds: number): CancelTimer
+  nextTick(cb: () => void): void
 }
 
 export type CancelTimer = () => void

--- a/src/shared/time/fake_clock.ts
+++ b/src/shared/time/fake_clock.ts
@@ -43,7 +43,7 @@ export class FakeClock implements Clock {
     return () => this.removeTask(id)
   }
 
-  public setImmediate(fn: () => void): CancelTimer {
+  public nextTick(fn: () => void): CancelTimer {
     const id = this.nextId++
     this.addTask({ id, nextTime: this.now() + Number.MIN_VALUE, fn })
     return () => this.removeTask(id)


### PR DESCRIPTION
This lets us use `process.nextTick` on the node side, and a faster equivalent to `setTimeout(fn, 0)` on the client side.

Also simplifies the interface, I don't think we'll ever use the `...args: any[]` part.