### PR TITLE
Add date() to Clock interface

### DIFF
--- a/src/client/time/browser_clock.ts
+++ b/src/client/time/browser_clock.ts
@@ -26,6 +26,7 @@ function performanceNow(): number {
 
 export const BrowserSystemClock: Clock = {
   now: () => Date.now() * MillisecondsToSeconds,
+  date: () => new Date(),
   performanceNow,
   setTimeout,
   setInterval,

--- a/src/server/time/node_clock.ts
+++ b/src/server/time/node_clock.ts
@@ -26,6 +26,7 @@ function performanceNow(): number {
 
 export const NodeSystemClock: Clock = {
   now: () => Date.now() * MillisecondsToSeconds,
+  date: () => new Date(),
   performanceNow,
   setTimeout,
   setInterval,

--- a/src/server/time/tests/fake_clock.tests.ts
+++ b/src/server/time/tests/fake_clock.tests.ts
@@ -22,10 +22,6 @@ describe('FakeClock', () => {
       expect(FakeClock.of().date().toUTCString()).toEqual('Thu, 01 Jan 1970 00:00:00 GMT')
     })
 
-    it('starts at unix epoch by default', () => {
-      expect(FakeClock.of().date().toUTCString()).toEqual('Thu, 01 Jan 1970 00:00:00 GMT')
-    })
-
     it('returns date at the initialized time', () => {
       expect(FakeClock.of(1492778724).date().toUTCString()).toEqual('Fri, 21 Apr 2017 12:45:24 GMT')
     })

--- a/src/server/time/tests/fake_clock.tests.ts
+++ b/src/server/time/tests/fake_clock.tests.ts
@@ -4,7 +4,31 @@ describe('FakeClock', () => {
   let clock: FakeClock
 
   beforeEach(() => {
-    clock = new FakeClock()
+    clock = FakeClock.of()
+  })
+
+  describe('#now', () => {
+    it('starts at 0 by default', () => {
+      expect(FakeClock.of().now()).toEqual(0)
+    })
+
+    it('returns time with initialized value', () => {
+      expect(FakeClock.of(1000).now()).toEqual(1000)
+    })
+  })
+
+  describe('#date', () => {
+    it('starts at unix epoch by default', () => {
+      expect(FakeClock.of().date().toUTCString()).toEqual('Thu, 01 Jan 1970 00:00:00 GMT')
+    })
+
+    it('starts at unix epoch by default', () => {
+      expect(FakeClock.of().date().toUTCString()).toEqual('Thu, 01 Jan 1970 00:00:00 GMT')
+    })
+
+    it('returns date at the initialized time', () => {
+      expect(FakeClock.of(1492778724).date().toUTCString()).toEqual('Fri, 21 Apr 2017 12:45:24 GMT')
+    })
   })
 
   describe('#tick', () => {

--- a/src/shared/time/clock.ts
+++ b/src/shared/time/clock.ts
@@ -1,5 +1,6 @@
 export interface Clock {
   now(): number
+  date(): Date,
   performanceNow(): number
   setTimeout(cb: () => void, seconds: number): CancelTimer
   setInterval(cb: () => void, seconds: number): CancelTimer

--- a/src/shared/time/clock.ts
+++ b/src/shared/time/clock.ts
@@ -1,6 +1,6 @@
 export interface Clock {
   now(): number
-  date(): Date,
+  date(): Date
   performanceNow(): number
   setTimeout(cb: () => void, seconds: number): CancelTimer
   setInterval(cb: () => void, seconds: number): CancelTimer

--- a/src/shared/time/fake_clock.ts
+++ b/src/shared/time/fake_clock.ts
@@ -1,6 +1,8 @@
 import { Clock } from './clock'
 import { CancelTimer } from './clock'
 
+const SecondsToMilliseconds = 1e3
+
 type Task = {
   id: number
   nextTime: number
@@ -13,18 +15,22 @@ export class FakeClock implements Clock {
   private time: number
   private tasks: Task[]
 
-  constructor() {
+  constructor(time: number) {
     this.nextId = 0
-    this.time = 0
+    this.time = time
     this.tasks = []
   }
 
-  public static of() {
-    return new FakeClock()
+  public static of(time: number = 0) {
+    return new FakeClock(time)
   }
 
   public now(): number {
     return this.time
+  }
+
+  public date(): Date {
+    return new Date(this.now() * SecondsToMilliseconds)
   }
 
   public performanceNow(): number {


### PR DESCRIPTION
Adds date functionality to the clock, supported by node + browser + fake.

Needed for recording!