### PR TITLE
Add unique id to robot model

### DIFF
--- a/src/client/components/app/network.ts
+++ b/src/client/components/app/network.ts
@@ -5,8 +5,11 @@ import { RobotModel } from '../robot/model'
 import { AppModel } from './model'
 
 export class AppNetwork {
+  private nextRobotId: number
   public constructor(private nusightNetwork: NUsightNetwork,
                      private model: AppModel) {
+    this.nextRobotId = 0
+
     nusightNetwork.onNUClearJoin(this.onJoin)
     nusightNetwork.onNUClearLeave(this.onLeave)
   }
@@ -28,7 +31,9 @@ export class AppNetwork {
       // Keep this in sync, since the port will likely change per connection.
       robot.port = peer.port
     } else {
+      const robotId = String(this.nextRobotId++)
       this.model.robots.push(RobotModel.of({
+        id: robotId,
         name: peer.name,
         address: peer.address,
         port: peer.port,

--- a/src/client/components/dashboard/dashboard_robot/model.ts
+++ b/src/client/components/dashboard/dashboard_robot/model.ts
@@ -30,8 +30,8 @@ export class DashboardRobotModel {
   // The timestamp of the last message from the robot (in seconds since an arbitrary time)
   @observable public time: number
 
-  // The id number of the robot
-  @observable public id: number
+  // The player id of the robot, typically 1 through N
+  @observable public playerId: number
 
   // The name of the role the robot is executing
   @observable public roleName: string
@@ -87,7 +87,7 @@ export class DashboardRobotModel {
       camera: Transform.of(),
       gameMode: Mode.UNKNOWN_MODE,
       gamePhase: Phase.UNKNOWN_PHASE,
-      id: -1,
+      playerId: -1,
       kickTarget: Vector2.of(),
       kickTargetColor: '#00796B',
       lastCameraImage: 0,
@@ -113,6 +113,11 @@ export class DashboardRobotModel {
   }
 
   @computed
+  public get id(): string {
+    return this.robot.id
+  }
+
+  @computed
   public get name(): string {
     return this.robot.name
   }
@@ -132,7 +137,6 @@ interface DashboardRobotModelOpts {
   robotColor: string
   textColor: string
   time: number
-  id: number
   roleName: string
   battery: number
   voltage: number
@@ -145,6 +149,7 @@ interface DashboardRobotModelOpts {
   gameMode: Mode
   gamePhase: Phase
   penaltyReason: PenaltyReason
+  playerId: number
   lastCameraImage: number
   lastSeenBall: number
   lastSeenGoal: number

--- a/src/client/components/dashboard/dashboard_robot/view_model.ts
+++ b/src/client/components/dashboard/dashboard_robot/view_model.ts
@@ -158,7 +158,7 @@ export class DashboardRobotViewModel {
         ),
         Shape.of(
           TextGeometry.of({
-            text: this.model.id.toString(),
+            text: this.model.playerId.toString(),
             textAlign: 'center',
             textBaseline: 'middle',
             maxWidth: radius,

--- a/src/client/components/dashboard/network.ts
+++ b/src/client/components/dashboard/network.ts
@@ -35,7 +35,7 @@ export class DashboardNetwork {
     robot.time = toSeconds(overview.timestamp)
 
     // The id number of the robot
-    robot.id = overview.robotId
+    robot.playerId = overview.robotId
 
     // Name of the executing binary
     robot.roleName = overview.roleName

--- a/src/client/components/dashboard/view.tsx
+++ b/src/client/components/dashboard/view.tsx
@@ -46,7 +46,7 @@ export class Dashboard extends Component<DashboardProps> {
               const model = RobotPanelViewModel.of(robot)
               return (
                 robot.enabled &&
-                <div className={style.panel} key={robot.name}>
+                <div className={style.panel} key={robot.id}>
                   <RobotPanel
                     connected={model.connected}
                     batteryValue={model.batteryValue}

--- a/src/client/components/robot/model.ts
+++ b/src/client/components/robot/model.ts
@@ -1,6 +1,7 @@
 import { observable } from 'mobx'
 
 export class RobotModel {
+  @observable public id: string
   @observable public connected: boolean
   @observable public enabled: boolean
   @observable public name: string

--- a/src/client/components/robot_selector/view.tsx
+++ b/src/client/components/robot_selector/view.tsx
@@ -42,7 +42,7 @@ export const RobotSelector = observer((props: RobotSelectorProps) => {
           }
           {robots.map(robot => {
             return (
-              <label key={robot.name} className={style.robot}>
+              <label key={robot.id} className={style.robot}>
                 <span className={style.robotLabel}>{robot.name}</span>
                 <Switch on={robot.enabled} onChange={onChange(robot)} />
               </label>


### PR DESCRIPTION
Prevents us trying to use `name` or some combination of `name`/`address`/`port` throughout the app, especially within react `key` properties.

Renames the current `id` property on `DashboardRobotModel` to `playerId`.