### PR TITLE
Fix nbs timestamp encoding

### DIFF
--- a/src/server/nbs/nbs_frame_codecs.ts
+++ b/src/server/nbs/nbs_frame_codecs.ts
@@ -34,8 +34,8 @@ export function encodeFrame(frame: NbsFrame): Buffer {
 
   const timeLong = Long.fromNumber(frame.timestampInMicroseconds)
   const timestampBuffer = new Buffer(TIMESTAMP_SIZE)
-  timestampBuffer.writeUInt32LE(timeLong.low, 0)
-  timestampBuffer.writeUInt32LE(timeLong.high, 4)
+  timestampBuffer.writeUInt32LE(timeLong.getLowBitsUnsigned(), 0)
+  timestampBuffer.writeUInt32LE(timeLong.getHighBitsUnsigned(), 4)
 
   return Buffer.concat([
     NBS_HEADER,

--- a/src/server/nbs/tests/nbs_frame_codecs.tests.ts
+++ b/src/server/nbs/tests/nbs_frame_codecs.tests.ts
@@ -14,6 +14,14 @@ describe('NbsFrameCodecs', () => {
       expect(buffer.toString('hex')).toEqual('e298a218000000c042f15c9654050010abef8b5398f0d41212121212121212')
     })
 
+    it('correctly encodes timestamps as unsigned integers', () => {
+      const hash = hashType('message.input.sensors')
+      const timestamp = -1 >>> 0 // Take any negative value and convert it to an unsigned integer.
+      const payload = new Buffer(8).fill(0x12)
+      const buffer = encodeFrame({ timestampInMicroseconds: timestamp, hash, payload })
+      expect(buffer.toString('hex')).toEqual('e298a218000000ffffffff0000000010abef8b5398f0d41212121212121212')
+    })
+
     it('errors if you supply an invalid hash size', () => {
       const hash = new Buffer(12)
       const timestamp = 1500379664696000

--- a/src/server/nbs/tests/nbs_frame_codecs.tests.ts
+++ b/src/server/nbs/tests/nbs_frame_codecs.tests.ts
@@ -14,7 +14,7 @@ describe('NbsFrameCodecs', () => {
       expect(buffer.toString('hex')).toEqual('e298a218000000c042f15c9654050010abef8b5398f0d41212121212121212')
     })
 
-    it('correctly encodes timestamps as unsigned integers', () => {
+    it('encodes timestamps as unsigned integers', () => {
       const hash = hashType('message.input.sensors')
       const timestamp = -1 >>> 0 // Take any negative value and convert it to an unsigned integer.
       const payload = new Buffer(8).fill(0x12)


### PR DESCRIPTION
Essentially, timestamps were not guaranteed to be written as an unsigned value because:
- `Long.fromNumber(-1).low === -1`
- `Long.fromNumber(-1).getLowBitsUnsigned() === 4294967295 === 0xFFFFFFFF`

So if the low 32 bits of the timestamp happened to be a negative value, the `writeUInt32LE` call in `encodeFrame` would throw with an out of bounds error.

By explicitly calling `getLowBitsUnsigned()` instead of accessing `low`, we're getting the correct unsigned value of the low bits.

p.s. this was already in the robocup recording branch, so they are all valid 🙂 