### PR TITLE
Add per-simulator frequency configuration

### DIFF
--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -59,11 +59,11 @@ function init() {
       fakeNetworking: true,
       numRobots: 3,
       simulators: [
-        OverviewSimulator.of(),
-        SensorDataSimulator.of(),
+        { frequency: 1, simulator: OverviewSimulator.of() },
+        { frequency: 60, simulator: SensorDataSimulator.of() },
       ],
     })
-    virtualRobots.simulateWithFrequency(60)
+    virtualRobots.startSimulators()
   }
 }
 

--- a/src/server/prod.ts
+++ b/src/server/prod.ts
@@ -35,11 +35,11 @@ if (withVirtualRobots) {
     fakeNetworking: true,
     numRobots: 3,
     simulators: [
-      SensorDataSimulator.of(),
-      OverviewSimulator.of(),
+      { frequency: 1, simulator: OverviewSimulator.of() },
+      { frequency: 60, simulator: SensorDataSimulator.of() },
     ],
   })
-  virtualRobots.simulateWithFrequency(60)
+  virtualRobots.startSimulators()
 }
 
 WebSocketProxyNUClearNetServer.of(WebSocketServer.of(sioNetwork.of('/nuclearnet')), {

--- a/src/virtual_robots/run.ts
+++ b/src/virtual_robots/run.ts
@@ -1,7 +1,7 @@
 import * as minimist from 'minimist'
 import { OverviewSimulator } from './simulators/overview_simulator'
 import { SensorDataSimulator } from './simulators/sensor_data_simulator'
-import { Simulator } from './simulator'
+import { SimulatorOpts } from './virtual_robot'
 import { VirtualRobots } from './virtual_robots'
 
 function main() {
@@ -13,16 +13,16 @@ function main() {
     numRobots: 6,
     simulators,
   })
-  virtualRobots.simulateWithFrequency(60)
+  virtualRobots.startSimulators()
 }
 
-function getSimulators(args: minimist.ParsedArgs): Simulator[] {
+function getSimulators(args: minimist.ParsedArgs): SimulatorOpts[] {
   const simulators = []
-  if (args.sensors || args.all) {
-    simulators.push(SensorDataSimulator.of())
-  }
   if (args.overview || args.all) {
-    simulators.push(OverviewSimulator.of())
+    simulators.push({ frequency: 1, simulator: OverviewSimulator.of() })
+  }
+  if (args.sensors || args.all) {
+    simulators.push({ frequency: 60, simulator: SensorDataSimulator.of() })
   }
   if (simulators.length === 0) {
     // If no simulators given, enable them all.

--- a/src/virtual_robots/virtual_robot.ts
+++ b/src/virtual_robots/virtual_robot.ts
@@ -1,24 +1,29 @@
-import { Simulator } from './simulator'
+import { DirectNUClearNetClient } from '../server/nuclearnet/direct_nuclearnet_client'
+import { FakeNUClearNetClient } from '../server/nuclearnet/fake_nuclearnet_client'
+import { NodeSystemClock } from '../server/time/node_clock'
 import { NUClearNetClient } from '../shared/nuclearnet/nuclearnet_client'
 import { Clock } from '../shared/time/clock'
-import { FakeNUClearNetClient } from '../server/nuclearnet/fake_nuclearnet_client'
-import { DirectNUClearNetClient } from '../server/nuclearnet/direct_nuclearnet_client'
-import { NodeSystemClock } from '../server/time/node_clock'
 import { flatMap } from './flat_map'
+import { Simulator } from './simulator'
 
 type Opts = {
   fakeNetworking: boolean
   name: string
-  simulators: Simulator[]
+  simulators: SimulatorOpts[]
+}
+
+export type SimulatorOpts = {
+  frequency: number,
+  simulator: Simulator
 }
 
 export class VirtualRobot {
   private name: string
-  private simulators: Simulator[]
+  private simulators: SimulatorOpts[]
 
   constructor(private network: NUClearNetClient,
               private clock: Clock,
-              opts: { name: string, simulators: Simulator[] }) {
+              opts: { name: string, simulators: SimulatorOpts[] }) {
     this.name = opts.name
     this.simulators = opts.simulators
   }
@@ -29,14 +34,16 @@ export class VirtualRobot {
     return new VirtualRobot(network, clock, opts)
   }
 
-  public simulateWithFrequency(frequency: number, index: number, numRobots: number) {
+  public startSimulators(index: number, numRobots: number) {
     const disconnect = this.connect()
 
-    const period = 1 / frequency
-    const cancelLoop = this.clock.setInterval(() => this.simulate(index, numRobots), period)
+    const stops = this.simulators.map(opts => {
+      const period = 1 / opts.frequency
+      return this.clock.setInterval(() => this.simulate(opts.simulator, index, numRobots), period)
+    })
 
     return () => {
-      cancelLoop()
+      stops.forEach(stop => stop())
       disconnect()
     }
   }
@@ -53,13 +60,19 @@ export class VirtualRobot {
     })
   }
 
-  public simulate(index: number, numRobots: number) {
-    const messages = flatMap(simulator => simulator.simulate(this.clock.now(), index, numRobots), this.simulators)
+  public simulateAll(index: number, numRobots: number) {
+    const messages = flatMap(opts => opts.simulator.simulate(this.clock.now(), index, numRobots), this.simulators)
     messages.forEach(message => this.send(message.messageType, message.buffer))
     return messages
   }
 
   public connect(): () => void {
     return this.network.connect({ name: this.name })
+  }
+
+  private simulate(simulator: Simulator, index: number, numRobots: number) {
+    const messages = simulator.simulate(this.clock.now(), index, numRobots)
+    messages.forEach(message => this.send(message.messageType, message.buffer))
+    return messages
   }
 }

--- a/src/virtual_robots/virtual_robots.ts
+++ b/src/virtual_robots/virtual_robots.ts
@@ -1,11 +1,11 @@
 import { range } from '../shared/base/range'
-import { Simulator } from './simulator'
 import { VirtualRobot } from './virtual_robot'
+import { SimulatorOpts } from './virtual_robot'
 
 type Opts = {
   fakeNetworking: boolean
   numRobots: number
-  simulators: Simulator[]
+  simulators: SimulatorOpts[]
 }
 
 export class VirtualRobots {
@@ -24,13 +24,13 @@ export class VirtualRobots {
     return new VirtualRobots({ robots })
   }
 
-  public simulateWithFrequency(frequency: number): () => void {
-    const stops = this.robots.map((robot, index) => robot.simulateWithFrequency(frequency, index, this.robots.length))
+  public startSimulators(): () => void {
+    const stops = this.robots.map((robot, index) => robot.startSimulators(index, this.robots.length))
     return () => stops.forEach(stop => stop())
   }
 
-  public simulate(): void {
-    this.robots.forEach((robot, index) => robot.simulate(index, this.robots.length))
+  public simulateAll(): void {
+    this.robots.forEach((robot, index) => robot.simulateAll(index, this.robots.length))
   }
 
   public connect(): void {


### PR DESCRIPTION
Not all simulators should be created equal. This PR adds the ability to specify a frequency for each type of simulator.

I suspect this configuration will end up living inside each simulator eventually, but good enough for now.

- #135
- #136 ← You are here
- #137