### PR TITLE
Remove @action annotations on models

### DIFF
--- a/src/client/canvas/object/group.ts
+++ b/src/client/canvas/object/group.ts
@@ -1,4 +1,3 @@
-import { action } from 'mobx'
 import { observable } from 'mobx'
 import { Transform } from '../../math/transform'
 import { Object2d } from './object2d'
@@ -27,7 +26,6 @@ export class Group implements Object2d {
     })
   }
 
-  @action
   public add(obj: Object2d): void {
     this.children.push(obj)
   }

--- a/src/client/canvas/object/shape.ts
+++ b/src/client/canvas/object/shape.ts
@@ -47,7 +47,6 @@ export class Shape implements Object2d {
     })
   }
 
-  @action
   public add(obj: Object2d): void {
     this.group.add(obj)
   }

--- a/src/client/components/localisation/model.ts
+++ b/src/client/components/localisation/model.ts
@@ -133,7 +133,6 @@ export class Quaternion {
     return new Quaternion(0, 0, 0, 1)
   }
 
-  @action
   public set(x: number, y: number, z: number, w: number): Quaternion {
     this.x = x
     this.y = y

--- a/src/client/math/matrix2.ts
+++ b/src/client/math/matrix2.ts
@@ -1,4 +1,3 @@
-import { action } from 'mobx'
 import { computed } from 'mobx'
 import { observable } from 'mobx'
 import { Vector2 } from './vector2'
@@ -30,19 +29,16 @@ export class Matrix2 {
     return this.x.x + this.y.y
   }
 
-  @action
   public set(x: Vector2, y: Vector2): Matrix2 {
     this.x = x
     this.y = y
     return this
   }
 
-  @action
   public clone(): Matrix2 {
     return new Matrix2(this.x.clone(), this.y.clone())
   }
 
-  @action
   public copy(m: Matrix2): Matrix2 {
     this.x.copy(m.x)
     this.y.copy(m.y)

--- a/src/client/math/matrix3.ts
+++ b/src/client/math/matrix3.ts
@@ -1,4 +1,3 @@
-import { action } from 'mobx'
 import { computed } from 'mobx'
 import { observable } from 'mobx'
 import { Vector3 } from './vector3'
@@ -33,7 +32,6 @@ export class Matrix3 {
     return this.x.x + this.y.y + this.z.z
   }
 
-  @action
   public set(x: Vector3, y: Vector3, z: Vector3): Matrix3 {
     this.x = x
     this.y = y
@@ -41,12 +39,10 @@ export class Matrix3 {
     return this
   }
 
-  @action
   public clone(): Matrix3 {
     return new Matrix3(this.x.clone(), this.y.clone(), this.z.clone())
   }
 
-  @action
   public copy(m: Matrix3): Matrix3 {
     this.x.copy(m.x)
     this.y.copy(m.y)

--- a/src/client/math/transform.ts
+++ b/src/client/math/transform.ts
@@ -1,4 +1,3 @@
-import { action } from 'mobx'
 import { observable } from 'mobx'
 
 export type Rotate = number
@@ -39,7 +38,6 @@ export class Transform {
     })
   }
 
-  @action
   public then(transform: Transform): Transform {
     const { anticlockwise, rotate, scale, translate } = transform
 
@@ -92,7 +90,6 @@ export class Transform {
     })
   }
 
-  @action
   public setTranslate(x: number, y: number): Transform {
     this.translate.x = x
     this.translate.y = y

--- a/src/client/math/vector2.ts
+++ b/src/client/math/vector2.ts
@@ -1,4 +1,3 @@
-import { action } from 'mobx'
 import { computed } from 'mobx'
 import { observable } from 'mobx'
 import { Transform } from './transform'
@@ -23,11 +22,11 @@ export class Vector2 {
     return new Vector2(vec.x || 0, vec.y || 0)
   }
 
-  @computed get length(): number {
+  @computed
+  get length(): number {
     return Math.sqrt(this.x * this.x + this.y * this.y)
   }
 
-  @action
   public transform(transform: Transform): Vector2 {
     const { rotate, scale, translate } = transform
 
@@ -50,26 +49,22 @@ export class Vector2 {
     return this
   }
 
-  @action
   public set(x: number, y: number): Vector2 {
     this.x = x
     this.y = y
     return this
   }
 
-  @action
   public clone(): Vector2 {
     return new Vector2(this.x, this.y)
   }
 
-  @action
   public copy(v: Vector2): Vector2 {
     this.x = v.x
     this.y = v.y
     return this
   }
 
-  @action
   public normalize(): Vector2 {
     // We should not use the computed property 'length' as mobx can throw out the following error when called in a
     // computed context for what should be a new, unobserved vector: Computed values are not allowed to cause side
@@ -78,14 +73,12 @@ export class Vector2 {
     return this.divideScalar(length)
   }
 
-  @action
   public multiplyScalar(scalarX: number, scalarY: number = scalarX): Vector2 {
     this.x *= scalarX
     this.y *= scalarY
     return this
   }
 
-  @action
   public divideScalar(scalarX: number, scalarY: number = scalarX): Vector2 {
     if (scalarX !== 0) {
       const invScalar = 1 / scalarX
@@ -104,14 +97,12 @@ export class Vector2 {
     return this
   }
 
-  @action
   public add(v: Vector2): Vector2 {
     this.x += v.x
     this.y += v.y
     return this
   }
 
-  @action
   public subtract(v: Vector2): Vector2 {
     this.x -= v.x
     this.y -= v.y

--- a/src/client/math/vector3.ts
+++ b/src/client/math/vector3.ts
@@ -1,4 +1,3 @@
-import { action } from 'mobx'
 import { computed } from 'mobx'
 import { observable } from 'mobx'
 
@@ -28,7 +27,6 @@ export class Vector3 {
     return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z)
   }
 
-  @action
   public set(x: number, y: number, z: number): Vector3 {
     this.x = x
     this.y = y
@@ -36,12 +34,10 @@ export class Vector3 {
     return this
   }
 
-  @action
   public clone(): Vector3 {
     return new Vector3(this.x, this.y, this.z)
   }
 
-  @action
   public copy(v: Vector3): Vector3 {
     this.x = v.x
     this.y = v.y
@@ -49,12 +45,10 @@ export class Vector3 {
     return this
   }
 
-  @action
   public normalize(): Vector3 {
     return this.divideScalar(this.length)
   }
 
-  @action
   public multiplyScalar(scalar: number): Vector3 {
     this.x *= scalar
     this.y *= scalar
@@ -62,7 +56,6 @@ export class Vector3 {
     return this
   }
 
-  @action
   public divideScalar(scalar: number): Vector3 {
     if (scalar !== 0) {
       const invScalar = 1 / scalar
@@ -77,7 +70,6 @@ export class Vector3 {
     return this
   }
 
-  @action
   public add(v: Vector3): Vector3 {
     this.x += v.x
     this.y += v.y
@@ -85,7 +77,6 @@ export class Vector3 {
     return this
   }
 
-  @action
   public subtract(v: Vector3): Vector3 {
     this.x -= v.x
     this.y -= v.y


### PR DESCRIPTION
There is no need for models to be annotated with `@action`.

Any consumer that uses these methods will already exist within a controller method which has an `@action` annotation.

i.e. these are redundant and also prevent the consumer from _needing_ to annotate themselves with `@action`.