### PR TITLE
Fix the hash function when the result isn't 16 characters

### DIFF
--- a/src/server/nuclearnet/fake_nuclearnet_server.ts
+++ b/src/server/nuclearnet/fake_nuclearnet_server.ts
@@ -86,7 +86,7 @@ export function hashType(type: string): Buffer {
   // See https://goo.gl/6NDPo2
   let hashString: string = XXH.h64(type, 0x4e55436c).toString(16)
   // The hash string may truncate if it's smaller than 16 characters so we pad it with 0s
-  hashString = `0000000000000000${hashString}`.slice(-16)
+  hashString = ('0'.repeat(16) + hashString).slice(-16)
 
   return Buffer.from((hashString.match(/../g) as string[]).reverse().join(''), 'hex')
 }

--- a/src/server/nuclearnet/fake_nuclearnet_server.ts
+++ b/src/server/nuclearnet/fake_nuclearnet_server.ts
@@ -84,6 +84,9 @@ export class FakeNUClearNetServer {
 export function hashType(type: string): Buffer {
   // Matches hashing implementation from NUClearNet
   // See https://goo.gl/6NDPo2
-  const hashString: string = XXH.h64(type, 0x4e55436c).toString(16)
+  let hashString: string = XXH.h64(type, 0x4e55436c).toString(16)
+  // The hash string may truncate if it's smaller than 16 characters so we pad it with 0s
+  hashString = `0000000000000000${hashString}`.slice(-16)
+
   return Buffer.from((hashString.match(/../g) as string[]).reverse().join(''), 'hex')
 }

--- a/src/server/nuclearnet/tests/__snapshots__/fake_nuclearnet_server.tests.ts.snap
+++ b/src/server/nuclearnet/tests/__snapshots__/fake_nuclearnet_server.tests.ts.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FakeNUClearNetServer #hashType matches previous snapshots 1`] = `
+Object {
+  "data": Array [
+    225,
+    233,
+    240,
+    189,
+    213,
+    194,
+    172,
+    79,
+  ],
+  "type": "Buffer",
+}
+`;
+
+exports[`FakeNUClearNetServer #hashType matches previous snapshots 2`] = `
+Object {
+  "data": Array [
+    188,
+    214,
+    134,
+    145,
+    61,
+    19,
+    178,
+    202,
+  ],
+  "type": "Buffer",
+}
+`;
+
+exports[`FakeNUClearNetServer #hashType matches previous snapshots 3`] = `
+Object {
+  "data": Array [
+    11,
+    128,
+    31,
+    158,
+    81,
+    99,
+    174,
+    59,
+  ],
+  "type": "Buffer",
+}
+`;
+
+exports[`FakeNUClearNetServer #hashType matches previous snapshots 4`] = `
+Object {
+  "data": Array [
+    89,
+    255,
+    223,
+    146,
+    90,
+    203,
+    129,
+    10,
+  ],
+  "type": "Buffer",
+}
+`;

--- a/src/server/nuclearnet/tests/fake_nuclearnet_server.tests.ts
+++ b/src/server/nuclearnet/tests/fake_nuclearnet_server.tests.ts
@@ -1,0 +1,20 @@
+import { hashType } from '../fake_nuclearnet_server'
+
+describe('FakeNUClearNetServer', () => {
+  describe('#hashType', () => {
+    it('matches previous snapshots', () => {
+      expect(hashType('foo')).toMatchSnapshot()
+      expect(hashType('bar')).toMatchSnapshot()
+      expect(hashType('baz')).toMatchSnapshot()
+      expect(hashType('cheesecake')).toMatchSnapshot()
+    })
+
+    it('ensures it returns 8 bytes', () => {
+      expect(hashType('foo').byteLength).toBe(8)
+      expect(hashType('bar').byteLength).toBe(8)
+      expect(hashType('baz').byteLength).toBe(8)
+      // cheesecake happens to hash to 7 bytes without padding.
+      expect(hashType('cheesecake').byteLength).toBe(8)
+    })
+  })
+})


### PR DESCRIPTION
When the hash code isn't 16 characters (because the MSBs are to small) the hash code was too short and broke everything.
This zero pads the resulting string to ensure it's always 16 characters.