### PR TITLE
Loosen member tslint restrictions

### DIFF
--- a/src/client/canvas/appearance/basic_appearance.ts
+++ b/src/client/canvas/appearance/basic_appearance.ts
@@ -1,9 +1,9 @@
 import { observable } from 'mobx'
 
 export class BasicAppearance {
-  @observable public fillStyle: string
-  @observable public lineWidth: number
-  @observable public strokeStyle: string
+  @observable fillStyle: string
+  @observable lineWidth: number
+  @observable strokeStyle: string
 
   constructor(opts: BasicAppearance) {
     this.fillStyle = opts.fillStyle
@@ -11,7 +11,7 @@ export class BasicAppearance {
     this.strokeStyle = opts.strokeStyle
   }
 
-  public static of({
+  static of({
     fillStyle = '#000',
     lineWidth = 1,
     strokeStyle = '#000',

--- a/src/client/canvas/appearance/line_appearance.ts
+++ b/src/client/canvas/appearance/line_appearance.ts
@@ -1,11 +1,11 @@
 import { observable } from 'mobx'
 
 export class LineAppearance {
-  @observable public lineCap: 'butt' | 'round' | 'square'
-  @observable public lineDashOffset: number
-  @observable public lineJoin: 'bevel' | 'round' | 'miter'
-  @observable public lineWidth: number
-  @observable public strokeStyle: string
+  @observable lineCap: 'butt' | 'round' | 'square'
+  @observable lineDashOffset: number
+  @observable lineJoin: 'bevel' | 'round' | 'miter'
+  @observable lineWidth: number
+  @observable strokeStyle: string
 
   constructor(opts: LineAppearance) {
     this.lineCap = opts.lineCap
@@ -15,7 +15,7 @@ export class LineAppearance {
     this.strokeStyle = opts.strokeStyle
   }
 
-  public static of({
+  static of({
     lineCap = 'butt',
     lineDashOffset = 0,
     lineJoin = 'miter',

--- a/src/client/canvas/geometry/arc_geometry.ts
+++ b/src/client/canvas/geometry/arc_geometry.ts
@@ -3,11 +3,11 @@ import { observable } from 'mobx'
 import { Vector2 } from '../../math/vector2'
 
 export class ArcGeometry {
-  @observable public origin: Vector2
-  @observable public radius: number
-  @observable public startAngle: number
-  @observable public endAngle: number
-  @observable public anticlockwise: boolean
+  @observable origin: Vector2
+  @observable radius: number
+  @observable startAngle: number
+  @observable endAngle: number
+  @observable anticlockwise: boolean
 
   constructor(opts: ArcGeometry) {
     this.origin = opts.origin
@@ -17,7 +17,7 @@ export class ArcGeometry {
     this.anticlockwise = opts.anticlockwise
   }
 
-  public static of({
+  static of({
                      origin = Vector2.of(0, 0),
                      radius = 1,
                      startAngle = 0,

--- a/src/client/canvas/geometry/arrow_geometry.ts
+++ b/src/client/canvas/geometry/arrow_geometry.ts
@@ -3,12 +3,12 @@ import { observable } from 'mobx'
 import { Vector2 } from '../../math/vector2'
 
 export class ArrowGeometry {
-  @observable public direction: Vector2
-  @observable public headLength: number
-  @observable public headWidth: number
-  @observable public length: number
-  @observable public origin: Vector2
-  @observable public width: number
+  @observable direction: Vector2
+  @observable headLength: number
+  @observable headWidth: number
+  @observable length: number
+  @observable origin: Vector2
+  @observable width: number
 
   constructor(opts: ArrowGeometry) {
     this.direction = opts.direction
@@ -19,7 +19,7 @@ export class ArrowGeometry {
     this.width = opts.width
   }
 
-  public static of({
+  static of({
     length = 1,
     direction = Vector2.of(1, 0),
     headLength = 0.2 * length,

--- a/src/client/canvas/geometry/circle_geometry.ts
+++ b/src/client/canvas/geometry/circle_geometry.ts
@@ -1,9 +1,9 @@
 import { observable } from 'mobx'
 
 export class CircleGeometry {
-  @observable public radius: number
-  @observable public x: number
-  @observable public y: number
+  @observable radius: number
+  @observable x: number
+  @observable y: number
 
   constructor(opts: CircleGeometry) {
     this.radius = opts.radius
@@ -11,7 +11,7 @@ export class CircleGeometry {
     this.y = opts.y
   }
 
-  public static of({
+  static of({
     radius = 1,
     x = 0,
     y = 0,

--- a/src/client/canvas/geometry/line_geometry.ts
+++ b/src/client/canvas/geometry/line_geometry.ts
@@ -3,15 +3,15 @@ import { observable } from 'mobx'
 import { Vector2 } from '../../math/vector2'
 
 export class LineGeometry {
-  @observable public origin: Vector2
-  @observable public target: Vector2
+  @observable origin: Vector2
+  @observable target: Vector2
 
   constructor(opts: LineGeometry) {
     this.origin = opts.origin
     this.target = opts.target
   }
 
-  public static of({
+  static of({
     origin = Vector2.of(0, 0),
     target = Vector2.of(1, 1),
   }: Partial<LineGeometry> = {}): LineGeometry {

--- a/src/client/canvas/geometry/marker_geometry.ts
+++ b/src/client/canvas/geometry/marker_geometry.ts
@@ -3,10 +3,10 @@ import { observable } from 'mobx'
 import { Vector2 } from '../../math/vector2'
 
 export class MarkerGeometry {
-  @observable public heading: Vector2
-  @observable public radius: number
-  @observable public x: number
-  @observable public y: number
+  @observable heading: Vector2
+  @observable radius: number
+  @observable x: number
+  @observable y: number
 
   constructor(opts: MarkerGeometry) {
     this.heading = opts.heading
@@ -15,7 +15,7 @@ export class MarkerGeometry {
     this.y = opts.y
   }
 
-  public static of({
+  static of({
     heading = Vector2.of(1, 0),
     radius = 1,
     x = 0,

--- a/src/client/canvas/geometry/polygon_geometry.ts
+++ b/src/client/canvas/geometry/polygon_geometry.ts
@@ -3,7 +3,7 @@ import { observable } from 'mobx'
 import { Vector2 } from '../../math/vector2'
 
 export class PolygonGeometry {
-  @observable public points: Vector2[]
+  @observable points: Vector2[]
 
   constructor(opts: PolygonGeometry) {
     const points = opts.points
@@ -13,7 +13,7 @@ export class PolygonGeometry {
     this.points = points
   }
 
-  public static of(points: Vector2[]): PolygonGeometry {
+  static of(points: Vector2[]): PolygonGeometry {
     return new PolygonGeometry({ points })
   }
 }

--- a/src/client/canvas/geometry/text_geometry.ts
+++ b/src/client/canvas/geometry/text_geometry.ts
@@ -5,15 +5,15 @@ import { Transform } from '../../math/transform'
 import { Geometry } from './geometry'
 
 export class TextGeometry implements Geometry {
-  @observable public alignToView: boolean
-  @observable public fontFamily: string
-  @observable public maxWidth: number
-  @observable public text: string
-  @observable public textAlign: 'start' | 'end' | 'left' | 'right' | 'center'
-  @observable public textBaseline: 'top' | 'hanging' | 'middle' | 'alphabetic' | 'ideographic' | 'bottom'
-  @observable public transform: Transform
-  @observable public x: number
-  @observable public y: number
+  @observable alignToView: boolean
+  @observable fontFamily: string
+  @observable maxWidth: number
+  @observable text: string
+  @observable textAlign: 'start' | 'end' | 'left' | 'right' | 'center'
+  @observable textBaseline: 'top' | 'hanging' | 'middle' | 'alphabetic' | 'ideographic' | 'bottom'
+  @observable transform: Transform
+  @observable x: number
+  @observable y: number
 
   constructor(opts: TextGeometry) {
     this.alignToView = opts.alignToView
@@ -27,7 +27,7 @@ export class TextGeometry implements Geometry {
     this.y = opts.y
   }
 
-  public static of({
+  static of({
     alignToView = true,
     fontFamily = 'sans-serif',
     maxWidth = 0.5,

--- a/src/client/canvas/object/group.ts
+++ b/src/client/canvas/object/group.ts
@@ -10,15 +10,15 @@ export type GroupOpts = {
 }
 
 export class Group implements Object2d {
-  @observable public children: Object2d[]
-  @observable public transform: Transform
+  @observable children: Object2d[]
+  @observable transform: Transform
 
-  public constructor(opts: GroupOpts) {
+  constructor(opts: GroupOpts) {
     this.children = opts.children
     this.transform = opts.transform
   }
 
-  public static of({
+  static of({
     children = [],
     transform = Transform.of(),
   }: Partial<GroupOpts> = {}): Group {
@@ -28,7 +28,7 @@ export class Group implements Object2d {
     })
   }
 
-  public add(obj: Object2d): void {
+  add(obj: Object2d): void {
     this.children.push(obj)
   }
 }

--- a/src/client/canvas/object/shape.ts
+++ b/src/client/canvas/object/shape.ts
@@ -30,8 +30,8 @@ export type ShapeOpts = {
 } & GroupOpts
 
 export class Shape implements Object2d {
-  @observable public appearance: Appearance
-  @observable public geometry: Geometry
+  @observable appearance: Appearance
+  @observable geometry: Geometry
   @observable private group: Group
 
   constructor(opts: ShapeOpts) {
@@ -40,7 +40,7 @@ export class Shape implements Object2d {
     this.group = Group.of(opts)
   }
 
-  public static of(geometry: Geometry, appearance: Appearance = BasicAppearance.of()) {
+  static of(geometry: Geometry, appearance: Appearance = BasicAppearance.of()) {
     return new Shape({
       appearance,
       children: [],
@@ -49,17 +49,17 @@ export class Shape implements Object2d {
     })
   }
 
-  public add(obj: Object2d): void {
+  add(obj: Object2d): void {
     this.group.add(obj)
   }
 
   @computed
-  public get children(): Object2d[] {
+  get children(): Object2d[] {
     return this.group.children
   }
 
   @computed
-  public get transform(): Transform {
+  get transform(): Transform {
     return this.group.transform
   }
 }

--- a/src/client/canvas/renderer.ts
+++ b/src/client/canvas/renderer.ts
@@ -19,11 +19,11 @@ export class CanvasRenderer {
   constructor(private context: CanvasRenderingContext2D) {
   }
 
-  public static of(context: CanvasRenderingContext2D): CanvasRenderer {
+  static of(context: CanvasRenderingContext2D): CanvasRenderer {
     return new CanvasRenderer(context)
   }
 
-  public render(scene: Group, camera: Transform = Transform.of()): void {
+  render(scene: Group, camera: Transform = Transform.of()): void {
     const canvas = this.context.canvas
     this.context.clearRect(0, 0, canvas.width, canvas.height)
     this.renderObjects(scene.children, camera.inverse().then(scene.transform))

--- a/src/client/components/app/controller.ts
+++ b/src/client/components/app/controller.ts
@@ -3,12 +3,12 @@ import { action } from 'mobx'
 import { RobotModel } from '../robot/model'
 
 export class AppController {
-  public static of() {
+  static of() {
     return new AppController()
   }
 
   @action
-  public toggleRobotEnabled(model: RobotModel) {
+  toggleRobotEnabled(model: RobotModel) {
     model.enabled = !model.enabled
   }
 }

--- a/src/client/components/app/model.ts
+++ b/src/client/components/app/model.ts
@@ -3,13 +3,13 @@ import { observable } from 'mobx'
 import { RobotModel } from '../robot/model'
 
 export class AppModel {
-  @observable public robots: RobotModel[]
+  @observable robots: RobotModel[]
 
   constructor(opts: AppModel) {
     Object.assign(this, opts)
   }
 
-  public static of(options: { robots: RobotModel[] } = { robots: [] }) {
+  static of(options: { robots: RobotModel[] } = { robots: [] }) {
     return new AppModel(options)
   }
 }

--- a/src/client/components/app/network.ts
+++ b/src/client/components/app/network.ts
@@ -8,15 +8,15 @@ import { AppModel } from './model'
 
 export class AppNetwork {
   private nextRobotId: number
-  public constructor(private nusightNetwork: NUsightNetwork,
-                     private model: AppModel) {
+  constructor(private nusightNetwork: NUsightNetwork,
+              private model: AppModel) {
     this.nextRobotId = 0
 
     nusightNetwork.onNUClearJoin(this.onJoin)
     nusightNetwork.onNUClearLeave(this.onLeave)
   }
 
-  public static of(nusightNetwork: NUsightNetwork, model: AppModel) {
+  static of(nusightNetwork: NUsightNetwork, model: AppModel) {
     return new AppNetwork(nusightNetwork, model)
   }
 

--- a/src/client/components/app/view.tsx
+++ b/src/client/components/app/view.tsx
@@ -6,7 +6,7 @@ import { NavigationView } from '../navigation/view'
 import * as style from './style.css'
 
 export class AppView extends React.Component<{ nav: NavigationConfiguration }> {
-  public render() {
+  render() {
     const { nav, children } = this.props
     return (
       <div className={style.app}>

--- a/src/client/components/dashboard/controller.ts
+++ b/src/client/components/dashboard/controller.ts
@@ -3,12 +3,12 @@ import { action } from 'mobx'
 import { DashboardModel } from './model'
 
 export class DashboardController {
-  public static of() {
+  static of() {
     return new DashboardController()
   }
 
   @action
-  public toggleOrientation(model: DashboardModel) {
+  toggleOrientation(model: DashboardModel) {
     model.field.orientation = model.field.orientation === 'left' ? 'right' : 'left'
   }
 }

--- a/src/client/components/dashboard/dashboard_robot/model.ts
+++ b/src/client/components/dashboard/dashboard_robot/model.ts
@@ -18,66 +18,66 @@ import Phase = message.input.GameState.Data.Phase
 export class DashboardRobotModel {
 
   // Parameters that influence the display
-  @observable public camera: Transform
-  @observable public ballColor: string
-  @observable public ballSightColor: string
-  @observable public kickTargetColor: string
+  @observable camera: Transform
+  @observable ballColor: string
+  @observable ballSightColor: string
+  @observable kickTargetColor: string
   @observable private robot: RobotModel
-  @observable public robotBorderColor: string
-  @observable public robotColor: string
-  @observable public textColor: string
+  @observable robotBorderColor: string
+  @observable robotColor: string
+  @observable textColor: string
 
   // Parameters from the network
   // The timestamp of the last message from the robot (in seconds since an arbitrary time)
-  @observable public time: number
+  @observable time: number
 
   // The player id of the robot, typically 1 through N
-  @observable public playerId: number
+  @observable playerId: number
 
   // The name of the role the robot is executing
-  @observable public roleName: string
+  @observable roleName: string
 
   // Battery as a value between 0 and 1 (percentage)
-  @observable public battery: number
+  @observable battery: number
 
   // The voltage of the battery
-  @observable public voltage: number
+  @observable voltage: number
 
   // The state of the behaviour as an enum
-  @observable public behaviourState: State
+  @observable behaviourState: State
 
   // The robots position and heading and associated covariance
-  @observable public robotPosition: Vector3 // x,y,theta
-  @observable public robotPositionCovariance: Matrix3
+  @observable robotPosition: Vector3 // x,y,theta
+  @observable robotPositionCovariance: Matrix3
 
   // The position of the ball on the field and associated covariance
-  @observable public ballPosition: Vector2
-  @observable public ballCovariance: Matrix2
+  @observable ballPosition: Vector2
+  @observable ballCovariance: Matrix2
 
   // The position on the field the robot is kicking towards
-  @observable public kickTarget: Vector2
+  @observable kickTarget: Vector2
 
   // The game state information
-  @observable public gameMode: Mode
-  @observable public gamePhase: Phase
-  @observable public penaltyReason: PenaltyReason
+  @observable gameMode: Mode
+  @observable gamePhase: Phase
+  @observable penaltyReason: PenaltyReason
 
   // The timestamp of when we last had an image, saw the ball and saw a goal
   // Measured in seconds compared to the variable `time`
-  @observable public lastCameraImage: number
-  @observable public lastSeenBall: number
-  @observable public lastSeenGoal: number
+  @observable lastCameraImage: number
+  @observable lastSeenBall: number
+  @observable lastSeenGoal: number
 
   // The walk plan and the current walk command
-  @observable public walkPathPlan: Vector2[]
-  @observable public walkCommand: Vector3
+  @observable walkPathPlan: Vector2[]
+  @observable walkCommand: Vector3
 
   constructor(robot: RobotModel, opts: DashboardRobotModelOpts) {
     this.robot = robot
     Object.assign(this, opts)
   }
 
-  public static of = memoize((robot: RobotModel): DashboardRobotModel => {
+  static of = memoize((robot: RobotModel): DashboardRobotModel => {
     return new DashboardRobotModel(robot, {
       ballColor: '#ff9800',
       ballCovariance: Matrix2.of(),
@@ -109,22 +109,22 @@ export class DashboardRobotModel {
   })
 
   @computed
-  public get connected(): boolean {
+  get connected(): boolean {
     return this.robot.connected
   }
 
   @computed
-  public get id(): string {
+  get id(): string {
     return this.robot.id
   }
 
   @computed
-  public get name(): string {
+  get name(): string {
     return this.robot.name
   }
 
   @computed
-  public get enabled(): boolean {
+  get enabled(): boolean {
     return this.robot.enabled
   }
 }

--- a/src/client/components/dashboard/dashboard_robot/view_model.ts
+++ b/src/client/components/dashboard/dashboard_robot/view_model.ts
@@ -17,15 +17,15 @@ import { Vector2 } from '../../../math/vector2'
 import { DashboardRobotModel } from './model'
 
 export class DashboardRobotViewModel {
-  public constructor(private model: DashboardRobotModel) {
+  constructor(private model: DashboardRobotModel) {
   }
 
-  public static of = createTransformer((model: DashboardRobotModel): DashboardRobotViewModel => {
+  static of = createTransformer((model: DashboardRobotModel): DashboardRobotViewModel => {
     return new DashboardRobotViewModel(model)
   })
 
   @computed
-  public get robot(): Group {
+  get robot(): Group {
     return Group.of({
       children: [
         this.fieldSpaceGroup,

--- a/src/client/components/dashboard/field/controller.ts
+++ b/src/client/components/dashboard/field/controller.ts
@@ -3,12 +3,12 @@ import { action } from 'mobx'
 import { FieldModel } from './model'
 
 export class FieldController {
-  public static of(): FieldController {
+  static of(): FieldController {
     return new FieldController()
   }
 
   @action
-  public onFieldResize(model: FieldModel, width: number, height: number) {
+  onFieldResize(model: FieldModel, width: number, height: number) {
     const fieldWidth = model.fieldWidth
     const fieldLength = model.fieldLength
     const scaleX = fieldLength / width

--- a/src/client/components/dashboard/field/model.ts
+++ b/src/client/components/dashboard/field/model.ts
@@ -14,10 +14,10 @@ export type FieldModelOpts = {
 }
 
 export class FieldModel {
-  @observable public camera: Transform
-  @observable public orientation: 'left' | 'right'
-  @observable public ground: GroundModel
-  @observable public robots: DashboardRobotModel[]
+  @observable camera: Transform
+  @observable orientation: 'left' | 'right'
+  @observable ground: GroundModel
+  @observable robots: DashboardRobotModel[]
 
   constructor(opts: FieldModelOpts) {
     this.camera = opts.camera
@@ -26,7 +26,7 @@ export class FieldModel {
     this.robots = opts.robots
   }
 
-  public static of = memoize((robots: DashboardRobotModel[]): FieldModel => {
+  static of = memoize((robots: DashboardRobotModel[]): FieldModel => {
     return new FieldModel({
       camera: Transform.of({ anticlockwise: false }),
       orientation: 'right',
@@ -36,14 +36,14 @@ export class FieldModel {
   })
 
   @computed
-  public get fieldLength() {
+  get fieldLength() {
     return this.ground.dimensions.fieldLength
       + (this.ground.dimensions.goalDepth * 2)
       + (this.ground.dimensions.borderStripMinWidth * 2)
   }
 
   @computed
-  public get fieldWidth() {
+  get fieldWidth() {
     return this.ground.dimensions.fieldWidth + (this.ground.dimensions.borderStripMinWidth * 2)
   }
 }

--- a/src/client/components/dashboard/field/view.tsx
+++ b/src/client/components/dashboard/field/view.tsx
@@ -24,7 +24,7 @@ export class Field extends Component<FieldProps> {
   private renderer: CanvasRenderer
   private stopAutorun: IReactionDisposer
 
-  public componentDidMount() {
+  componentDidMount() {
     if (!this.field) {
       return
     }
@@ -34,11 +34,11 @@ export class Field extends Component<FieldProps> {
     this.rafId = requestAnimationFrame(this.onAnimationFrame)
   }
 
-  public componentWillUnmount() {
+  componentWillUnmount() {
     cancelAnimationFrame(this.rafId)
   }
 
-  public render() {
+  render() {
     return <canvas className={style.field} ref={this.onRef}/>
   }
 

--- a/src/client/components/dashboard/field/view_model.ts
+++ b/src/client/components/dashboard/field/view_model.ts
@@ -9,15 +9,15 @@ import { GroundViewModel } from '../ground/view_model'
 import { FieldModel } from './model'
 
 export class FieldViewModel {
-  public constructor(private model: FieldModel) {
+  constructor(private model: FieldModel) {
   }
 
-  public static of = createTransformer((model: FieldModel): FieldViewModel => {
+  static of = createTransformer((model: FieldModel): FieldViewModel => {
     return new FieldViewModel(model)
   })
 
   @computed
-  public get scene(): Group {
+  get scene(): Group {
     return Group.of({
       transform: Transform.of({
         // TODO (Annable): move camera to the view model and put this transform there.

--- a/src/client/components/dashboard/ground/model.ts
+++ b/src/client/components/dashboard/ground/model.ts
@@ -3,17 +3,17 @@ import { observable } from 'mobx'
 import { FieldDimensions } from '../../../../shared/field/dimensions'
 
 export class GroundModel {
-  @observable public bottomGoalColor: string
-  @observable public dimensions: FieldDimensions
-  @observable public fieldColor: string
-  @observable public lineColor: string
-  @observable public topGoalColor: string
+  @observable bottomGoalColor: string
+  @observable dimensions: FieldDimensions
+  @observable fieldColor: string
+  @observable lineColor: string
+  @observable topGoalColor: string
 
-  public constructor(opts: GroundModel) {
+  constructor(opts: GroundModel) {
     Object.assign(this, opts)
   }
 
-  public static of() {
+  static of() {
     return new GroundModel({
       bottomGoalColor: 'blue',
       dimensions: FieldDimensions.postYear2017(),

--- a/src/client/components/dashboard/ground/view_model.ts
+++ b/src/client/components/dashboard/ground/view_model.ts
@@ -13,15 +13,15 @@ import { Vector2 } from '../../../math/vector2'
 import { GroundModel } from './model'
 
 export class GroundViewModel {
-  public constructor(private model: GroundModel) {
+  constructor(private model: GroundModel) {
   }
 
-  public static of = createTransformer((model: GroundModel): GroundViewModel => {
+  static of = createTransformer((model: GroundModel): GroundViewModel => {
     return new GroundViewModel(model)
   })
 
   @computed
-  public get ground(): Group {
+  get ground(): Group {
     return Group.of({
       children: [
         this.grass,

--- a/src/client/components/dashboard/model.ts
+++ b/src/client/components/dashboard/model.ts
@@ -13,17 +13,17 @@ export class DashboardModel {
     this.robotModels = robotModels
   }
 
-  public static of(robots: RobotModel[]): DashboardModel {
+  static of(robots: RobotModel[]): DashboardModel {
     return new DashboardModel(robots)
   }
 
   @computed
-  public get field(): FieldModel {
+  get field(): FieldModel {
     return FieldModel.of(this.robots)
   }
 
   @computed
-  public get robots(): DashboardRobotModel[] {
+  get robots(): DashboardRobotModel[] {
     return this.robotModels.map(robot => DashboardRobotModel.of(robot))
   }
 }

--- a/src/client/components/dashboard/network.ts
+++ b/src/client/components/dashboard/network.ts
@@ -15,16 +15,16 @@ import Timestamp = google.protobuf.Timestamp$Properties
 import Overview = message.support.nubugger.Overview
 
 export class DashboardNetwork {
-  public constructor(private network: Network) {
+  constructor(private network: Network) {
     this.network.on(Overview, this.onOverview)
   }
 
-  public static of(nusightNetwork: NUsightNetwork): DashboardNetwork {
+  static of(nusightNetwork: NUsightNetwork): DashboardNetwork {
     const network = Network.of(nusightNetwork)
     return new DashboardNetwork(network)
   }
 
-  public destroy() {
+  destroy() {
     this.network.off()
   }
 

--- a/src/client/components/dashboard/robot_panel/view_model.ts
+++ b/src/client/components/dashboard/robot_panel/view_model.ts
@@ -13,10 +13,10 @@ const Phase = message.input.GameState.Data.Phase
 import { LastStatus } from './view'
 
 export class RobotPanelViewModel {
-  public constructor(private model: DashboardRobotModel) {
+  constructor(private model: DashboardRobotModel) {
   }
 
-  public static of = createTransformer((model: DashboardRobotModel): RobotPanelViewModel => {
+  static of = createTransformer((model: DashboardRobotModel): RobotPanelViewModel => {
     return new RobotPanelViewModel(model)
   })
 
@@ -25,57 +25,57 @@ export class RobotPanelViewModel {
   }
 
   @computed
-  public get batteryValue(): string {
+  get batteryValue(): string {
     const battery = this.model.battery
     return battery === -1 ? '' : `${Math.round(battery * 100)}%`
   }
 
   @computed
-  public get behaviour(): string {
+  get behaviour(): string {
     return State[this.model.behaviourState] || State[State.UNKNOWN]
   }
 
   @computed
-  public get lastCameraImage(): LastStatus {
+  get lastCameraImage(): LastStatus {
     return this.getLastStatus(this.model.lastCameraImage, 5)
   }
 
   @computed
-  public get lastSeenBall(): LastStatus {
+  get lastSeenBall(): LastStatus {
     return this.getLastStatus(this.model.lastSeenBall, 30)
   }
 
   @computed
-  public get lastSeenGoal(): LastStatus {
+  get lastSeenGoal(): LastStatus {
     return this.getLastStatus(this.model.lastSeenGoal, 30)
   }
 
   @computed
-  public get mode(): string {
+  get mode(): string {
     return Mode[this.model.gameMode] || Mode[Mode.UNKNOWN_MODE]
   }
 
   @computed
-  public get penalised(): boolean {
+  get penalised(): boolean {
     return this.model.penaltyReason !== PenaltyReason.UNPENALISED
   }
 
   @computed
-  public get penalty(): string {
+  get penalty(): string {
     return PenaltyReason[this.model.penaltyReason] || PenaltyReason[PenaltyReason.UNKNOWN_PENALTY_REASON]
   }
 
   @computed
-  public get phase(): string {
+  get phase(): string {
     return Phase[this.model.gamePhase] || Phase[Phase.UNKNOWN_PHASE]
   }
 
   @computed
-  public get title(): string {
+  get title(): string {
     return this.model.name
   }
 
-  public get walkCommand(): Vector3 {
+  get walkCommand(): Vector3 {
     return this.model.walkCommand
   }
 

--- a/src/client/components/dashboard/view.tsx
+++ b/src/client/components/dashboard/view.tsx
@@ -20,11 +20,11 @@ export type DashboardProps = {
 
 @observer
 export class Dashboard extends Component<DashboardProps> {
-  public componentWillUnmount(): void {
+  componentWillUnmount(): void {
     this.props.network.destroy()
   }
 
-  public render() {
+  render() {
     const { menu: Menu, model } = this.props
     const showPanels = model.robots.some(robot => robot.enabled)
     const Field = this.props.Field

--- a/src/client/components/dropdown_container/view.tsx
+++ b/src/client/components/dropdown_container/view.tsx
@@ -25,7 +25,7 @@ export const dropdownContainer = (WrappedComponent: ComponentType<DropdownProps>
     @observable private isOpen: boolean = false
     private removeListeners: () => void
 
-    public componentDidMount() {
+    componentDidMount() {
       const onClick = (event: MouseEvent) => this.onDocumentClick(event)
       document.addEventListener('click', onClick)
 
@@ -38,13 +38,13 @@ export const dropdownContainer = (WrappedComponent: ComponentType<DropdownProps>
       }
     }
 
-    public componentWillUnmount() {
+    componentWillUnmount() {
       if (this.removeListeners) {
         this.removeListeners()
       }
     }
 
-    public render(): JSX.Element {
+    render(): JSX.Element {
       return (
         <WrappedComponent {...this.props}
           isOpen={this.isOpen}

--- a/src/client/components/localisation/controller.ts
+++ b/src/client/components/localisation/controller.ts
@@ -17,18 +17,18 @@ interface KeyModifiers {
 }
 
 export class LocalisationController {
-  public static of(): LocalisationController {
+  static of(): LocalisationController {
     return new LocalisationController()
   }
 
   @action
-  public onAnimationFrame(model: LocalisationModel, time: number) {
+  onAnimationFrame(model: LocalisationModel, time: number) {
     model.time.time = time / 1000
     this.updatePosition(model)
   }
 
   @action
-  public onLeftClick(model: LocalisationModel, requestPointerLock: () => void) {
+  onLeftClick(model: LocalisationModel, requestPointerLock: () => void) {
     if (!model.locked) {
       requestPointerLock()
     } else {
@@ -37,14 +37,14 @@ export class LocalisationController {
   }
 
   @action
-  public onRightClick(model: LocalisationModel) {
+  onRightClick(model: LocalisationModel) {
     if (model.locked) {
       model.target = this.getPreviousTarget(model)
     }
   }
 
   @action
-  public onHawkEyeClick(model: LocalisationModel) {
+  onHawkEyeClick(model: LocalisationModel) {
     model.controls.pitch = -Math.PI / 2
     model.controls.yaw = Math.PI / 2
     model.camera.position.set(0, 0, 5)
@@ -53,12 +53,12 @@ export class LocalisationController {
   }
 
   @action
-  public onPointerLockChange(model: LocalisationModel, locked: boolean): void {
+  onPointerLockChange(model: LocalisationModel, locked: boolean): void {
     model.locked = locked
   }
 
   @action
-  public onMouseMove(model: LocalisationModel, movementX: number, movementY: number): void {
+  onMouseMove(model: LocalisationModel, movementX: number, movementY: number): void {
     if (!model.locked || model.viewMode === ViewMode.FirstPerson) {
       return
     }
@@ -69,13 +69,13 @@ export class LocalisationController {
   }
 
   @action
-  public onWheel(model: LocalisationModel, deltaY: number): void {
+  onWheel(model: LocalisationModel, deltaY: number): void {
     const newDistance = model.camera.distance + deltaY / 1000
     model.camera.distance = Math.min(10, Math.max(0.1, newDistance))
   }
 
   @action
-  public onKeyDown(model: LocalisationModel, key: KeyCode, modifiers: KeyModifiers): void {
+  onKeyDown(model: LocalisationModel, key: KeyCode, modifiers: KeyModifiers): void {
     if (model.locked) {
       switch (key) {
         case KeyCode.W:
@@ -122,7 +122,7 @@ export class LocalisationController {
   }
 
   @action
-  public onKeyUp(model: LocalisationModel, key: KeyCode): void {
+  onKeyUp(model: LocalisationModel, key: KeyCode): void {
     if (model.locked) {
       switch (key) {
         case KeyCode.W:

--- a/src/client/components/localisation/darwin_robot/body/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/body/view_model.ts
@@ -14,15 +14,15 @@ import { RightLegViewModel } from '../right_leg/view_model'
 import * as BodyConfig from './config/body.json'
 
 export class BodyViewModel {
-  public constructor(private model: LocalisationRobotModel) {
+  constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: LocalisationRobotModel): BodyViewModel => {
+  static of = createTransformer((model: LocalisationRobotModel): BodyViewModel => {
     return new BodyViewModel(model)
   })
 
   @computed
-  public get body(): Mesh {
+  get body(): Mesh {
     const { geometry, materials } = this.bodyGeometryAndMaterial
     const mesh = new Mesh(geometry, new MultiMaterial(materials))
     mesh.position.set(0, 0, 0.096)

--- a/src/client/components/localisation/darwin_robot/head/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/head/view_model.ts
@@ -17,12 +17,12 @@ export class HeadViewModel {
   constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: LocalisationRobotModel): HeadViewModel => {
+  static of = createTransformer((model: LocalisationRobotModel): HeadViewModel => {
     return new HeadViewModel(model)
   })
 
   @computed
-  public get head() {
+  get head() {
     const head = new Object3D()
     head.add(this.neck)
     return head

--- a/src/client/components/localisation/darwin_robot/left_arm/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/left_arm/view_model.ts
@@ -15,12 +15,12 @@ export class LeftArmViewModel {
   constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: LocalisationRobotModel): LeftArmViewModel => {
+  static of = createTransformer((model: LocalisationRobotModel): LeftArmViewModel => {
     return new LeftArmViewModel(model)
   })
 
   @computed
-  public get leftArm() {
+  get leftArm() {
     const leftArm = new Object3D()
     leftArm.add(this.leftShoulder)
     return leftArm

--- a/src/client/components/localisation/darwin_robot/left_leg/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/left_leg/view_model.ts
@@ -18,12 +18,12 @@ export class LeftLegViewModel {
   constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: LocalisationRobotModel): LeftLegViewModel => {
+  static of = createTransformer((model: LocalisationRobotModel): LeftLegViewModel => {
     return new LeftLegViewModel(model)
   })
 
   @computed
-  public get leftLeg() {
+  get leftLeg() {
     const leftLeg = new Object3D()
     leftLeg.add(this.leftPelvisY)
     return leftLeg

--- a/src/client/components/localisation/darwin_robot/model.ts
+++ b/src/client/components/localisation/darwin_robot/model.ts
@@ -8,18 +8,18 @@ import { Quaternion } from '../model'
 
 export class LocalisationRobotModel {
   @observable private model: RobotModel
-  @observable public name: string
-  @observable public color?: string
-  @observable public rWTt: Vector3 // Torso to world translation in torso space.
-  @observable public Rwt: Quaternion // Torso to world rotation.
-  @observable public motors: DarwinMotorSet
+  @observable name: string
+  @observable color?: string
+  @observable rWTt: Vector3 // Torso to world translation in torso space.
+  @observable Rwt: Quaternion // Torso to world rotation.
+  @observable motors: DarwinMotorSet
 
-  public constructor(model: RobotModel, opts: Partial<LocalisationRobotModel>) {
+  constructor(model: RobotModel, opts: Partial<LocalisationRobotModel>) {
     this.model = model
     Object.assign(this, opts)
   }
 
-  public static of = memoize((model: RobotModel): LocalisationRobotModel => {
+  static of = memoize((model: RobotModel): LocalisationRobotModel => {
     return new LocalisationRobotModel(model, {
       name: model.name,
       rWTt: Vector3.of(),
@@ -34,32 +34,32 @@ export class LocalisationRobotModel {
 }
 
 export class DarwinMotorSet {
-  @observable public rightShoulderPitch: DarwinMotor
-  @observable public leftShoulderPitch: DarwinMotor
-  @observable public rightShoulderRoll: DarwinMotor
-  @observable public leftShoulderRoll: DarwinMotor
-  @observable public rightElbow: DarwinMotor
-  @observable public leftElbow: DarwinMotor
-  @observable public rightHipYaw: DarwinMotor
-  @observable public leftHipYaw: DarwinMotor
-  @observable public rightHipRoll: DarwinMotor
-  @observable public leftHipRoll: DarwinMotor
-  @observable public rightHipPitch: DarwinMotor
-  @observable public leftHipPitch: DarwinMotor
-  @observable public rightKnee: DarwinMotor
-  @observable public leftKnee: DarwinMotor
-  @observable public rightAnklePitch: DarwinMotor
-  @observable public leftAnklePitch: DarwinMotor
-  @observable public rightAnkleRoll: DarwinMotor
-  @observable public leftAnkleRoll: DarwinMotor
-  @observable public headPan: DarwinMotor
-  @observable public headTilt: DarwinMotor
+  @observable rightShoulderPitch: DarwinMotor
+  @observable leftShoulderPitch: DarwinMotor
+  @observable rightShoulderRoll: DarwinMotor
+  @observable leftShoulderRoll: DarwinMotor
+  @observable rightElbow: DarwinMotor
+  @observable leftElbow: DarwinMotor
+  @observable rightHipYaw: DarwinMotor
+  @observable leftHipYaw: DarwinMotor
+  @observable rightHipRoll: DarwinMotor
+  @observable leftHipRoll: DarwinMotor
+  @observable rightHipPitch: DarwinMotor
+  @observable leftHipPitch: DarwinMotor
+  @observable rightKnee: DarwinMotor
+  @observable leftKnee: DarwinMotor
+  @observable rightAnklePitch: DarwinMotor
+  @observable leftAnklePitch: DarwinMotor
+  @observable rightAnkleRoll: DarwinMotor
+  @observable leftAnkleRoll: DarwinMotor
+  @observable headPan: DarwinMotor
+  @observable headTilt: DarwinMotor
 
-  public constructor(opts: DarwinMotorSet) {
+  constructor(opts: DarwinMotorSet) {
     Object.assign(this, opts)
   }
 
-  public static of() {
+  static of() {
     return new DarwinMotorSet({
       rightShoulderPitch: DarwinMotor.of(),
       leftShoulderPitch: DarwinMotor.of(),
@@ -86,13 +86,13 @@ export class DarwinMotorSet {
 }
 
 class DarwinMotor {
-  @observable public angle: number
+  @observable angle: number
 
-  public constructor(opts: DarwinMotor) {
+  constructor(opts: DarwinMotor) {
     Object.assign(this, opts)
   }
 
-  public static of() {
+  static of() {
     return new DarwinMotor({ angle: 0 })
   }
 }

--- a/src/client/components/localisation/darwin_robot/right_arm/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/right_arm/view_model.ts
@@ -15,12 +15,12 @@ export class RightArmViewModel {
   constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: LocalisationRobotModel): RightArmViewModel => {
+  static of = createTransformer((model: LocalisationRobotModel): RightArmViewModel => {
     return new RightArmViewModel(model)
   })
 
   @computed
-  public get rightArm() {
+  get rightArm() {
     const rightArm = new Object3D()
     rightArm.add(this.rightShoulder)
     return rightArm

--- a/src/client/components/localisation/darwin_robot/right_leg/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/right_leg/view_model.ts
@@ -18,12 +18,12 @@ export class RightLegViewModel {
   constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: LocalisationRobotModel): RightLegViewModel => {
+  static of = createTransformer((model: LocalisationRobotModel): RightLegViewModel => {
     return new RightLegViewModel(model)
   })
 
   @computed
-  public get rightLeg() {
+  get rightLeg() {
     const rightLeg = new Object3D()
     rightLeg.add(this.rightPelvisY)
     return rightLeg

--- a/src/client/components/localisation/darwin_robot/view_model.ts
+++ b/src/client/components/localisation/darwin_robot/view_model.ts
@@ -9,15 +9,15 @@ import { LocalisationRobotModel } from './model'
 export const HIP_TO_FOOT = 0.2465
 
 export class RobotViewModel {
-  public constructor(private model: LocalisationRobotModel) {
+  constructor(private model: LocalisationRobotModel) {
   }
 
-  public static of = createTransformer((model: LocalisationRobotModel): RobotViewModel => {
+  static of = createTransformer((model: LocalisationRobotModel): RobotViewModel => {
     return new RobotViewModel(model)
   })
 
   @computed
-  public get robot(): Object3D {
+  get robot(): Object3D {
     const robot = new Object3D()
     robot.position.x = this.model.rWTt.x
     robot.position.y = this.model.rWTt.y

--- a/src/client/components/localisation/field/model.ts
+++ b/src/client/components/localisation/field/model.ts
@@ -3,17 +3,17 @@ import { observable } from 'mobx'
 import { FieldDimensions } from '../../../../shared/field/dimensions'
 
 export class FieldModel {
-  @observable public dimensions: FieldDimensions
-  @observable public fieldColor: string
-  @observable public lineColor: string
+  @observable dimensions: FieldDimensions
+  @observable fieldColor: string
+  @observable lineColor: string
 
-  public constructor({ dimensions, fieldColor, lineColor }: FieldModelOpts) {
+  constructor({ dimensions, fieldColor, lineColor }: FieldModelOpts) {
     this.dimensions = dimensions
     this.fieldColor = fieldColor
     this.lineColor = lineColor
   }
 
-  public static of() {
+  static of() {
     return new FieldModel({
       dimensions: FieldDimensions.postYear2017(),
       fieldColor: '#009900',

--- a/src/client/components/localisation/field/view_model.ts
+++ b/src/client/components/localisation/field/view_model.ts
@@ -11,15 +11,15 @@ import { Geometry } from 'three'
 import { FieldModel } from './model'
 
 export class FieldViewModel {
-  public constructor(private model: FieldModel) {
+  constructor(private model: FieldModel) {
   }
 
-  public static of = createTransformer((model: FieldModel): FieldViewModel => {
+  static of = createTransformer((model: FieldModel): FieldViewModel => {
     return new FieldViewModel(model)
   })
 
   @computed
-  public get field() {
+  get field() {
     const field = new Object3D()
     field.add(this.ground)
     field.add(this.fieldLines)

--- a/src/client/components/localisation/model.ts
+++ b/src/client/components/localisation/model.ts
@@ -10,14 +10,14 @@ import { FieldModel } from './field/model'
 import { SkyboxModel } from './skybox/model'
 
 export class TimeModel {
-  @observable public time: number // seconds
-  @observable public lastRenderTime: number // seconds
+  @observable time: number // seconds
+  @observable lastRenderTime: number // seconds
 
   constructor(opts: Partial<TimeModel>) {
     Object.assign(this, opts)
   }
 
-  public static of() {
+  static of() {
     return new TimeModel({
       time: 0,
       lastRenderTime: 0,
@@ -37,22 +37,22 @@ export enum ViewMode {
 
 export class LocalisationModel {
   @observable private appModel: AppModel
-  @observable public aspect: number
-  @observable public field: FieldModel
-  @observable public skybox: SkyboxModel
-  @observable public camera: CameraModel
-  @observable public locked: boolean
-  @observable public controls: ControlsModel
-  @observable public viewMode: ViewMode
-  @observable public target?: LocalisationRobotModel
-  @observable public time: TimeModel
+  @observable aspect: number
+  @observable field: FieldModel
+  @observable skybox: SkyboxModel
+  @observable camera: CameraModel
+  @observable locked: boolean
+  @observable controls: ControlsModel
+  @observable viewMode: ViewMode
+  @observable target?: LocalisationRobotModel
+  @observable time: TimeModel
 
   constructor(appModel: AppModel, opts: Partial<LocalisationModel>) {
     this.appModel = appModel
     Object.assign(this, opts)
   }
 
-  public static of = memoize((appModel: AppModel): LocalisationModel => {
+  static of = memoize((appModel: AppModel): LocalisationModel => {
     return new LocalisationModel(appModel, {
       aspect: 300 / 150,
       field: FieldModel.of(),
@@ -71,16 +71,16 @@ export class LocalisationModel {
 }
 
 class CameraModel {
-  @observable public position: Vector3
-  @observable public yaw: number
-  @observable public pitch: number
-  @observable public distance: number
+  @observable position: Vector3
+  @observable yaw: number
+  @observable pitch: number
+  @observable distance: number
 
   constructor(opts: CameraModel) {
     Object.assign(this, opts)
   }
 
-  public static of() {
+  static of() {
     return new CameraModel({
       position: new Vector3(-1, 0, 1),
       yaw: 0,
@@ -91,20 +91,20 @@ class CameraModel {
 }
 
 export class ControlsModel {
-  @observable public forward: boolean
-  @observable public left: boolean
-  @observable public right: boolean
-  @observable public back: boolean
-  @observable public up: boolean
-  @observable public down: boolean
-  @observable public pitch: number
-  @observable public yaw: number
+  @observable forward: boolean
+  @observable left: boolean
+  @observable right: boolean
+  @observable back: boolean
+  @observable up: boolean
+  @observable down: boolean
+  @observable pitch: number
+  @observable yaw: number
 
   constructor(opts: ControlsModel) {
     Object.assign(this, opts)
   }
 
-  public static of() {
+  static of() {
     return new ControlsModel({
       forward: false,
       left: false,
@@ -119,23 +119,23 @@ export class ControlsModel {
 }
 
 export class Quaternion {
-  @observable public x: number
-  @observable public y: number
-  @observable public z: number
-  @observable public w: number
+  @observable x: number
+  @observable y: number
+  @observable z: number
+  @observable w: number
 
-  public constructor(x: number, y: number, z: number, w: number) {
+  constructor(x: number, y: number, z: number, w: number) {
     this.x = x
     this.y = y
     this.z = z
     this.w = w
   }
 
-  public static of() {
+  static of() {
     return new Quaternion(0, 0, 0, 1)
   }
 
-  public set(x: number, y: number, z: number, w: number): Quaternion {
+  set(x: number, y: number, z: number, w: number): Quaternion {
     this.x = x
     this.y = y
     this.z = z

--- a/src/client/components/localisation/network.ts
+++ b/src/client/components/localisation/network.ts
@@ -14,17 +14,17 @@ import { LocalisationModel } from './model'
 import Sensors = message.input.Sensors
 
 export class LocalisationNetwork {
-  public constructor(private network: Network,
-                     private model: LocalisationModel) {
+  constructor(private network: Network,
+              private model: LocalisationModel) {
     this.network.on(Sensors, this.onSensors)
   }
 
-  public static of(nusightNetwork: NUsightNetwork, model: LocalisationModel): LocalisationNetwork {
+  static of(nusightNetwork: NUsightNetwork, model: LocalisationModel): LocalisationNetwork {
     const network = Network.of(nusightNetwork)
     return new LocalisationNetwork(network, model)
   }
 
-  public destroy() {
+  destroy() {
     this.network.off()
   }
 

--- a/src/client/components/localisation/skybox/model.ts
+++ b/src/client/components/localisation/skybox/model.ts
@@ -2,20 +2,20 @@ import { observable } from 'mobx'
 
 export class SkyboxModel {
 
-  @observable public turbidity: number
-  @observable public rayleigh: number
-  @observable public mieCoefficient: number
-  @observable public mieDirectionalG: number // default 0.8
-  @observable public luminance: number
-  @observable public inclination: number // elevation / inclination
-  @observable public azimuth: number // Facing front,
-  @observable public showSun: boolean
+  @observable turbidity: number
+  @observable rayleigh: number
+  @observable mieCoefficient: number
+  @observable mieDirectionalG: number // default 0.8
+  @observable luminance: number
+  @observable inclination: number // elevation / inclination
+  @observable azimuth: number // Facing front,
+  @observable showSun: boolean
 
-  public constructor(opts: SkyboxModel) {
+  constructor(opts: SkyboxModel) {
     Object.assign(this, opts)
   }
 
-  public static of() {
+  static of() {
     return new SkyboxModel({
       turbidity: 10,
       rayleigh: 2,

--- a/src/client/components/localisation/skybox/view_model.ts
+++ b/src/client/components/localisation/skybox/view_model.ts
@@ -15,15 +15,15 @@ import * as SkyboxVert from './skybox.vert'
 
 export class SkyboxViewModel {
 
-  public constructor(private model: SkyboxModel) {
+  constructor(private model: SkyboxModel) {
   }
 
-  public static of = createTransformer((model: SkyboxModel): SkyboxViewModel => {
+  static of = createTransformer((model: SkyboxModel): SkyboxViewModel => {
     return new SkyboxViewModel(model)
   })
 
   @computed
-  public get skybox() {
+  get skybox() {
     // reference: http://threejs.org/examples/#webgl_shaders_sky
     const skybox = new Object3D()
 

--- a/src/client/components/localisation/view.tsx
+++ b/src/client/components/localisation/view.tsx
@@ -27,7 +27,7 @@ export class LocalisationView extends React.Component<LocalisationViewProps> {
   private stopAutorun: IReactionDisposer
   private rafId: number
 
-  public componentDidMount(): void {
+  componentDidMount(): void {
     this.renderer = new WebGLRenderer({
       canvas: this.canvas,
       antialias: true,
@@ -42,7 +42,7 @@ export class LocalisationView extends React.Component<LocalisationViewProps> {
     this.rafId = requestAnimationFrame(this.onAnimationFrame)
   }
 
-  public componentWillUnmount(): void {
+  componentWillUnmount(): void {
     this.stopAutorun()
     this.canvas.removeEventListener('click', this.onClick, false)
     document.removeEventListener('pointerlockchange', this.onPointerLockChange, false)
@@ -54,7 +54,7 @@ export class LocalisationView extends React.Component<LocalisationViewProps> {
     this.props.network.destroy()
   }
 
-  public render(): JSX.Element {
+  render(): JSX.Element {
     return (
       <div className={style.localisation}>
         <LocalisationMenuBar menu={this.props.menu} onHawkEyeClick={this.onHawkEyeClick}/>
@@ -70,7 +70,7 @@ export class LocalisationView extends React.Component<LocalisationViewProps> {
     )
   }
 
-  public requestPointerLock() {
+  requestPointerLock() {
     this.canvas.requestPointerLock()
   }
 

--- a/src/client/components/localisation/view_model.ts
+++ b/src/client/components/localisation/view_model.ts
@@ -12,15 +12,15 @@ import { LocalisationModel } from './model'
 import { SkyboxViewModel } from './skybox/view_model'
 
 export class LocalisationViewModel {
-  public constructor(private model: LocalisationModel) {
+  constructor(private model: LocalisationModel) {
   }
 
-  public static of = createTransformer((model: LocalisationModel) => {
+  static of = createTransformer((model: LocalisationModel) => {
     return new LocalisationViewModel(model)
   })
 
   @computed
-  public get scene(): Scene {
+  get scene(): Scene {
     const scene = new Scene()
     this.robots.forEach(robot => scene.add(robot))
 
@@ -32,7 +32,7 @@ export class LocalisationViewModel {
   }
 
   @computed
-  public get camera(): PerspectiveCamera {
+  get camera(): PerspectiveCamera {
     const camera = new PerspectiveCamera(75, this.model.aspect, 0.01, 100)
     camera.position.set(this.model.camera.position.x, this.model.camera.position.y, this.model.camera.position.z)
     camera.rotation.set(Math.PI / 2 + this.model.camera.pitch, 0, -Math.PI / 2 + this.model.camera.yaw, 'ZXY')

--- a/src/client/components/robot/model.ts
+++ b/src/client/components/robot/model.ts
@@ -1,18 +1,18 @@
 import { observable } from 'mobx'
 
 export class RobotModel {
-  @observable public id: string
-  @observable public connected: boolean
-  @observable public enabled: boolean
-  @observable public name: string
-  @observable public address: string
-  @observable public port: number
+  @observable id: string
+  @observable connected: boolean
+  @observable enabled: boolean
+  @observable name: string
+  @observable address: string
+  @observable port: number
 
-  public constructor(opts: RobotModel) {
+  constructor(opts: RobotModel) {
     Object.assign(this, opts)
   }
 
-  public static of(opts: RobotModel) {
+  static of(opts: RobotModel) {
     return new RobotModel(opts)
   }
 }

--- a/src/client/math/matrix2.ts
+++ b/src/client/math/matrix2.ts
@@ -4,19 +4,19 @@ import { observable } from 'mobx'
 import { Vector2 } from './vector2'
 
 export class Matrix2 {
-  @observable public x: Vector2
-  @observable public y: Vector2
+  @observable x: Vector2
+  @observable y: Vector2
 
-  public constructor(x: Vector2, y: Vector2) {
+  constructor(x: Vector2, y: Vector2) {
     this.x = x
     this.y = y
   }
 
-  public static of() {
+  static of() {
     return new Matrix2(new Vector2(1, 0), new Vector2(0, 1))
   }
 
-  public static from(mat?: {
+  static from(mat?: {
     x?: { x?: number, y?: number },
     y?: { x?: number, y?: number }
   } | null): Matrix2 {
@@ -30,17 +30,17 @@ export class Matrix2 {
     return this.x.x + this.y.y
   }
 
-  public set(x: Vector2, y: Vector2): Matrix2 {
+  set(x: Vector2, y: Vector2): Matrix2 {
     this.x = x
     this.y = y
     return this
   }
 
-  public clone(): Matrix2 {
+  clone(): Matrix2 {
     return new Matrix2(this.x.clone(), this.y.clone())
   }
 
-  public copy(m: Matrix2): Matrix2 {
+  copy(m: Matrix2): Matrix2 {
     this.x.copy(m.x)
     this.y.copy(m.y)
     return this

--- a/src/client/math/matrix3.ts
+++ b/src/client/math/matrix3.ts
@@ -4,21 +4,21 @@ import { observable } from 'mobx'
 import { Vector3 } from './vector3'
 
 export class Matrix3 {
-  @observable public x: Vector3
-  @observable public y: Vector3
-  @observable public z: Vector3
+  @observable x: Vector3
+  @observable y: Vector3
+  @observable z: Vector3
 
-  public constructor(x: Vector3, y: Vector3, z: Vector3) {
+  constructor(x: Vector3, y: Vector3, z: Vector3) {
     this.x = x
     this.y = y
     this.z = z
   }
 
-  public static of() {
+  static of() {
     return new Matrix3(new Vector3(1, 0, 0), new Vector3(0, 1, 0), new Vector3(0, 0, 1))
   }
 
-  public static from(mat?: {
+  static from(mat?: {
     x?: { x?: number, y?: number, z?: number },
     y?: { x?: number, y?: number, z?: number },
     z?: { x?: number, y?: number, z?: number }
@@ -33,18 +33,18 @@ export class Matrix3 {
     return this.x.x + this.y.y + this.z.z
   }
 
-  public set(x: Vector3, y: Vector3, z: Vector3): Matrix3 {
+  set(x: Vector3, y: Vector3, z: Vector3): Matrix3 {
     this.x = x
     this.y = y
     this.z = z
     return this
   }
 
-  public clone(): Matrix3 {
+  clone(): Matrix3 {
     return new Matrix3(this.x.clone(), this.y.clone(), this.z.clone())
   }
 
-  public copy(m: Matrix3): Matrix3 {
+  copy(m: Matrix3): Matrix3 {
     this.x.copy(m.x)
     this.y.copy(m.y)
     this.z.copy(m.z)

--- a/src/client/math/transform.ts
+++ b/src/client/math/transform.ts
@@ -12,19 +12,19 @@ export type TransformOpts = {
 }
 
 export class Transform {
-  @observable public anticlockwise: boolean
-  @observable public rotate: Rotate
-  @observable public scale: Scale
-  @observable public translate: Translate
+  @observable anticlockwise: boolean
+  @observable rotate: Rotate
+  @observable scale: Scale
+  @observable translate: Translate
 
-  public constructor(opts: TransformOpts) {
+  constructor(opts: TransformOpts) {
     this.anticlockwise = opts.anticlockwise
     this.rotate = opts.rotate
     this.scale = opts.scale
     this.translate = opts.translate
   }
 
-  public static of({
+  static of({
                      anticlockwise = true,
                      rotate = 0,
                      scale = { x: 1, y: 1 },
@@ -38,7 +38,7 @@ export class Transform {
     })
   }
 
-  public then(transform: Transform): Transform {
+  then(transform: Transform): Transform {
     const { anticlockwise, rotate, scale, translate } = transform
 
     const scaleX = this.scale.x
@@ -66,7 +66,7 @@ export class Transform {
     return this
   }
 
-  public inverse(): Transform {
+  inverse(): Transform {
     return new Transform({
       anticlockwise: this.anticlockwise,
       scale: { x: 1 / this.scale.x, y: 1 / this.scale.y },
@@ -75,7 +75,7 @@ export class Transform {
     })
   }
 
-  public clone(): Transform {
+  clone(): Transform {
     return new Transform({
       anticlockwise: this.anticlockwise,
       rotate: this.rotate,
@@ -90,7 +90,7 @@ export class Transform {
     })
   }
 
-  public setTranslate(x: number, y: number): Transform {
+  setTranslate(x: number, y: number): Transform {
     this.translate.x = x
     this.translate.y = y
     return this

--- a/src/client/math/vector2.ts
+++ b/src/client/math/vector2.ts
@@ -4,19 +4,19 @@ import { observable } from 'mobx'
 import { Transform } from './transform'
 
 export class Vector2 {
-  @observable public x: number
-  @observable public y: number
+  @observable x: number
+  @observable y: number
 
-  public constructor(x: number, y: number) {
+  constructor(x: number, y: number) {
     this.x = x
     this.y = y
   }
 
-  public static of(x?: number, y?: number): Vector2 {
+  static of(x?: number, y?: number): Vector2 {
     return new Vector2(x || 0, y || 0)
   }
 
-  public static from(vec?: { x?: number, y?: number } | null): Vector2 {
+  static from(vec?: { x?: number, y?: number } | null): Vector2 {
     if (!vec) {
       return Vector2.of()
     }
@@ -28,7 +28,7 @@ export class Vector2 {
     return Math.sqrt(this.x * this.x + this.y * this.y)
   }
 
-  public transform(transform: Transform): Vector2 {
+  transform(transform: Transform): Vector2 {
     const { rotate, scale, translate } = transform
 
     const theta = rotate * (transform.anticlockwise ? 1 : -1)
@@ -50,23 +50,23 @@ export class Vector2 {
     return this
   }
 
-  public set(x: number, y: number): Vector2 {
+  set(x: number, y: number): Vector2 {
     this.x = x
     this.y = y
     return this
   }
 
-  public clone(): Vector2 {
+  clone(): Vector2 {
     return new Vector2(this.x, this.y)
   }
 
-  public copy(v: Vector2): Vector2 {
+  copy(v: Vector2): Vector2 {
     this.x = v.x
     this.y = v.y
     return this
   }
 
-  public normalize(): Vector2 {
+  normalize(): Vector2 {
     // We should not use the computed property 'length' as mobx can throw out the following error when called in a
     // computed context for what should be a new, unobserved vector: Computed values are not allowed to cause side
     // effects by changing observables that are already being observed.
@@ -74,13 +74,13 @@ export class Vector2 {
     return this.divideScalar(length)
   }
 
-  public multiplyScalar(scalarX: number, scalarY: number = scalarX): Vector2 {
+  multiplyScalar(scalarX: number, scalarY: number = scalarX): Vector2 {
     this.x *= scalarX
     this.y *= scalarY
     return this
   }
 
-  public divideScalar(scalarX: number, scalarY: number = scalarX): Vector2 {
+  divideScalar(scalarX: number, scalarY: number = scalarX): Vector2 {
     if (scalarX !== 0) {
       const invScalar = 1 / scalarX
       this.x *= invScalar
@@ -98,13 +98,13 @@ export class Vector2 {
     return this
   }
 
-  public add(v: Vector2): Vector2 {
+  add(v: Vector2): Vector2 {
     this.x += v.x
     this.y += v.y
     return this
   }
 
-  public subtract(v: Vector2): Vector2 {
+  subtract(v: Vector2): Vector2 {
     this.x -= v.x
     this.y -= v.y
     return this

--- a/src/client/math/vector3.ts
+++ b/src/client/math/vector3.ts
@@ -2,21 +2,21 @@ import { computed } from 'mobx'
 import { observable } from 'mobx'
 
 export class Vector3 {
-  @observable public x: number
-  @observable public y: number
-  @observable public z: number
+  @observable x: number
+  @observable y: number
+  @observable z: number
 
-  public constructor(x: number, y: number, z: number) {
+  constructor(x: number, y: number, z: number) {
     this.x = x
     this.y = y
     this.z = z
   }
 
-  public static of() {
+  static of() {
     return new Vector3(0, 0, 0)
   }
 
-  public static from(vec?: { x?: number, y?: number, z?: number } | null): Vector3 {
+  static from(vec?: { x?: number, y?: number, z?: number } | null): Vector3 {
     if (!vec) {
       return Vector3.of()
     }
@@ -27,36 +27,36 @@ export class Vector3 {
     return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z)
   }
 
-  public set(x: number, y: number, z: number): Vector3 {
+  set(x: number, y: number, z: number): Vector3 {
     this.x = x
     this.y = y
     this.z = z
     return this
   }
 
-  public clone(): Vector3 {
+  clone(): Vector3 {
     return new Vector3(this.x, this.y, this.z)
   }
 
-  public copy(v: Vector3): Vector3 {
+  copy(v: Vector3): Vector3 {
     this.x = v.x
     this.y = v.y
     this.z = v.z
     return this
   }
 
-  public normalize(): Vector3 {
+  normalize(): Vector3 {
     return this.divideScalar(this.length)
   }
 
-  public multiplyScalar(scalar: number): Vector3 {
+  multiplyScalar(scalar: number): Vector3 {
     this.x *= scalar
     this.y *= scalar
     this.z *= scalar
     return this
   }
 
-  public divideScalar(scalar: number): Vector3 {
+  divideScalar(scalar: number): Vector3 {
     if (scalar !== 0) {
       const invScalar = 1 / scalar
       this.x *= invScalar
@@ -70,14 +70,14 @@ export class Vector3 {
     return this
   }
 
-  public add(v: Vector3): Vector3 {
+  add(v: Vector3): Vector3 {
     this.x += v.x
     this.y += v.y
     this.z += v.z
     return this
   }
 
-  public subtract(v: Vector3): Vector3 {
+  subtract(v: Vector3): Vector3 {
     this.x -= v.x
     this.y -= v.y
     this.z -= v.z

--- a/src/client/navigation.tsx
+++ b/src/client/navigation.tsx
@@ -12,15 +12,15 @@ type Route = {
 export class NavigationConfiguration {
   private routes: Route[] = []
 
-  public static of() {
+  static of() {
     return new NavigationConfiguration()
   }
 
-  public addRoute(route: Route) {
+  addRoute(route: Route) {
     this.routes.push(route)
   }
 
-  public getRoutes() {
+  getRoutes() {
     return this.routes
   }
 }

--- a/src/client/network/message_type_names.ts
+++ b/src/client/network/message_type_names.ts
@@ -12,16 +12,16 @@ export class MessageTypePath {
   private cache: Map<any, string>
   private searchObject: any
 
-  public constructor() {
+  constructor() {
     this.searchObject = { message }
     this.cache = new Map()
   }
 
-  public static of = createSingletonFactory(() => {
+  static of = createSingletonFactory(() => {
     return new MessageTypePath()
   })
 
-  public getPath<T>(messageType: MessageType<T>): string {
+  getPath<T>(messageType: MessageType<T>): string {
     if (!this.cache.has(messageType)) {
       const path = findPath(this.searchObject, value => value === messageType)
       if (!path) {

--- a/src/client/network/network.ts
+++ b/src/client/network/network.ts
@@ -11,11 +11,11 @@ export class Network {
   // Store all event listener removers, so we can call them all in off().
   private offNUClearMessages: Set<() => void>
 
-  public constructor(private nusightNetwork: NUsightNetwork) {
+  constructor(private nusightNetwork: NUsightNetwork) {
     this.offNUClearMessages = new Set()
   }
 
-  public static of(nusightNetwork: NUsightNetwork): Network {
+  static of(nusightNetwork: NUsightNetwork): Network {
     return new Network(nusightNetwork)
   }
 
@@ -26,7 +26,7 @@ export class Network {
    * @param cb The callback to call every time a message is received
    * @returns A unsubscriber function.
    */
-  public on<T>(messageType: MessageType<T>, cb: MessageCallback<T>): () => void {
+  on<T>(messageType: MessageType<T>, cb: MessageCallback<T>): () => void {
     const offNUClearMessage = this.nusightNetwork.onNUClearMessage(messageType, cb)
     this.offNUClearMessages.add(offNUClearMessage)
     return () => {
@@ -38,7 +38,7 @@ export class Network {
   /**
    * Unsubscribe from all events that is currently being listened to.
    */
-  public off() {
+  off() {
     for (const offNUClearMessage of this.offNUClearMessages.values()) {
       offNUClearMessage()
     }

--- a/src/client/network/nusight_network.ts
+++ b/src/client/network/nusight_network.ts
@@ -17,22 +17,22 @@ const HEADER_SIZE = 9
  * instead create their own ComponentNetwork class which uses the Network helper class.
  */
 export class NUsightNetwork {
-  public constructor(private nuclearnetClient: NUClearNetClient,
-                     private appModel: AppModel,
-                     private messageTypePath: MessageTypePath) {
+  constructor(private nuclearnetClient: NUClearNetClient,
+              private appModel: AppModel,
+              private messageTypePath: MessageTypePath) {
   }
 
-  public static of(appModel: AppModel) {
+  static of(appModel: AppModel) {
     const messageTypePath = MessageTypePath.of()
     const nuclearnetClient: NUClearNetClient = WebSocketProxyNUClearNetClient.of()
     return new NUsightNetwork(nuclearnetClient, appModel, messageTypePath)
   }
 
-  public connect(opts: NUClearNetOptions): () => void {
+  connect(opts: NUClearNetOptions): () => void {
     return this.nuclearnetClient.connect(opts)
   }
 
-  public onNUClearMessage<T>(messageType: MessageType<T>, cb: MessageCallback<T>) {
+  onNUClearMessage<T>(messageType: MessageType<T>, cb: MessageCallback<T>) {
     const messageTypeName = this.messageTypePath.getPath(messageType)
     return this.nuclearnetClient.on(messageTypeName, (packet: NUClearNetPacket) => {
       const buffer = new Uint8Array(packet.payload)
@@ -47,11 +47,11 @@ export class NUsightNetwork {
     })
   }
 
-  public onNUClearJoin(cb: (peer: NUClearNetPeer) => void) {
+  onNUClearJoin(cb: (peer: NUClearNetPeer) => void) {
     this.nuclearnetClient.onJoin(cb)
   }
 
-  public onNUClearLeave(cb: (peer: NUClearNetPeer) => void) {
+  onNUClearLeave(cb: (peer: NUClearNetPeer) => void) {
     this.nuclearnetClient.onLeave(cb)
   }
 }

--- a/src/client/nuclearnet/web_socket_client.ts
+++ b/src/client/nuclearnet/web_socket_client.ts
@@ -7,31 +7,31 @@ import * as SocketIO from 'socket.io-client'
  * There should never be enough logic in here that it needs any testing.
  */
 export class WebSocketClient {
-  public constructor(private socket: SocketIOClient.Socket) {
+  constructor(private socket: SocketIOClient.Socket) {
   }
 
-  public static of(uri: string, opts: SocketIOClient.ConnectOpts) {
+  static of(uri: string, opts: SocketIOClient.ConnectOpts) {
     const socket = SocketIO(uri, opts)
     return new WebSocketClient(socket)
   }
 
-  public connect() {
+  connect() {
     this.socket = this.socket.connect()
   }
 
-  public disconnect() {
+  disconnect() {
     this.socket.disconnect()
   }
 
-  public on(event: string, fn: Function) {
+  on(event: string, fn: Function) {
     this.socket.on(event, fn)
   }
 
-  public off(event: string, fn?: Function) {
+  off(event: string, fn?: Function) {
     this.socket.off(event, fn)
   }
 
-  public send(event: string, ...args: any[]) {
+  send(event: string, ...args: any[]) {
     this.socket.emit(event, ...args)
   }
 }

--- a/src/client/nuclearnet/web_socket_proxy_nuclearnet_client.ts
+++ b/src/client/nuclearnet/web_socket_proxy_nuclearnet_client.ts
@@ -23,14 +23,14 @@ export class WebSocketProxyNUClearNetClient implements NUClearNetClient {
   private leaveListeners: Set<NUClearEventListener>
   private packetListeners: Map<string, Set<{ requestToken: string, listener: PacketListener }>>
 
-  public constructor(private socket: WebSocketClient) {
+  constructor(private socket: WebSocketClient) {
     this.nextRequestToken = 0
     this.joinListeners = new Set()
     this.leaveListeners = new Set()
     this.packetListeners = new Map()
   }
 
-  public static of() {
+  static of() {
     const uri = `${document.location.origin}/nuclearnet`
     return new WebSocketProxyNUClearNetClient(WebSocketClient.of(uri, {
       upgrade: false,
@@ -38,7 +38,7 @@ export class WebSocketProxyNUClearNetClient implements NUClearNetClient {
     }))
   }
 
-  public connect(options: NUClearNetOptions): () => void {
+  connect(options: NUClearNetOptions): () => void {
     this.socket.connect()
     this.socket.on('reconnect', this.onReconnect.bind(this, options))
     this.socket.send('nuclear_connect', options)
@@ -50,7 +50,7 @@ export class WebSocketProxyNUClearNetClient implements NUClearNetClient {
     }
   }
 
-  public onJoin(listener: NUClearEventListener): () => void {
+  onJoin(listener: NUClearEventListener): () => void {
     this.socket.on('nuclear_join', listener)
     this.joinListeners.add(listener)
     return () => {
@@ -59,7 +59,7 @@ export class WebSocketProxyNUClearNetClient implements NUClearNetClient {
     }
   }
 
-  public onLeave(listener: NUClearEventListener): () => void {
+  onLeave(listener: NUClearEventListener): () => void {
     this.socket.on('nuclear_leave', listener)
     this.leaveListeners.add(listener)
     return () => {
@@ -68,7 +68,7 @@ export class WebSocketProxyNUClearNetClient implements NUClearNetClient {
     }
   }
 
-  public on(event: string, cb: NUClearPacketListener): () => void {
+  on(event: string, cb: NUClearPacketListener): () => void {
     /*
      * This one is a bit more complicated than the others, mostly for performance purposes.
      *
@@ -112,11 +112,11 @@ export class WebSocketProxyNUClearNetClient implements NUClearNetClient {
     }
   }
 
-  public onPacket(cb: NUClearPacketListener): () => void {
+  onPacket(cb: NUClearPacketListener): () => void {
     return this.on('nuclear_packet', cb)
   }
 
-  public send(options: NUClearNetSend): void {
+  send(options: NUClearNetSend): void {
     if (typeof options.type === 'string') {
       this.socket.send(options.type, options)
     }

--- a/src/server/nbs/nbs_frame_chunker.ts
+++ b/src/server/nbs/nbs_frame_chunker.ts
@@ -24,11 +24,11 @@ export class NbsFrameChunker extends stream.Transform {
     this.foundPacketSize = false
   }
 
-  public static of(): NbsFrameChunker {
+  static of(): NbsFrameChunker {
     return new NbsFrameChunker()
   }
 
-  public _transform(chunk: any, encoding: string, done: (err?: any, data?: any) => void) {
+  _transform(chunk: any, encoding: string, done: (err?: any, data?: any) => void) {
     // Buffer any received data so that we can find nbs packets within it.
     this.buffers.push(chunk)
 

--- a/src/server/nbs/nbs_frame_streams.ts
+++ b/src/server/nbs/nbs_frame_streams.ts
@@ -10,17 +10,17 @@ import { decodeFrame } from './nbs_frame_codecs'
  * Expected to be useful for writing NbsFrame objects to streams, e.g. saving them to disk with a writable file stream.
  */
 export class NbsFrameEncoder extends stream.Transform {
-  public constructor() {
+  constructor() {
     super({
       objectMode: true,
     })
   }
 
-  public static of() {
+  static of() {
     return new NbsFrameEncoder()
   }
 
-  public _transform(frame: NbsFrame, encoding: string, done: (err?: any, data?: any) => void) {
+  _transform(frame: NbsFrame, encoding: string, done: (err?: any, data?: any) => void) {
     this.push(encodeFrame(frame))
     done()
   }
@@ -32,17 +32,17 @@ export class NbsFrameEncoder extends stream.Transform {
  * Expected to be used in combination with NbsFrameChunker to read from a readable file stream.
  */
 export class NbsFrameDecoder extends stream.Transform {
-  public constructor() {
+  constructor() {
     super({
       objectMode: true,
     })
   }
 
-  public static of() {
+  static of() {
     return new NbsFrameDecoder()
   }
 
-  public _transform(buffer: Buffer, encoding: string, done: (err?: any, data?: any) => void) {
+  _transform(buffer: Buffer, encoding: string, done: (err?: any, data?: any) => void) {
     this.push(decodeFrame(buffer))
     done()
   }

--- a/src/server/nbs/nbs_nuclear_playback.ts
+++ b/src/server/nbs/nbs_nuclear_playback.ts
@@ -27,19 +27,19 @@ export class NbsNUClearPlayback extends stream.Writable {
   private firstFrameTimestamp?: number
   private firstLocalTimestamp?: number
 
-  public constructor(private nuclearnetClient: NUClearNetClient,
-                     private clock: Clock) {
+  constructor(private nuclearnetClient: NUClearNetClient,
+              private clock: Clock) {
     super({
       objectMode: true,
     })
   }
 
-  public static of(nuclearnetClient: NUClearNetClient) {
+  static of(nuclearnetClient: NUClearNetClient) {
     return new NbsNUClearPlayback(nuclearnetClient, NodeSystemClock)
   }
 
   /** Convenience method for directly streaming a file to the network. */
-  public static fromFile(filename: string, nuclearnetClient: NUClearNetClient) {
+  static fromFile(filename: string, nuclearnetClient: NUClearNetClient) {
     const playback = NbsNUClearPlayback.of(nuclearnetClient)
     const rawStream = fs.createReadStream(filename)
     const isGzipped = filename.endsWith('.nbz') || filename.endsWith('.nbs.gz')
@@ -48,13 +48,13 @@ export class NbsNUClearPlayback extends stream.Writable {
     return playback
   }
 
-  public static fromRawStream(rawStream: ReadStream, nuclearnetClient: NUClearNetClient) {
+  static fromRawStream(rawStream: ReadStream, nuclearnetClient: NUClearNetClient) {
     const playback = NbsNUClearPlayback.of(nuclearnetClient)
     rawStream.pipe(new NbsFrameChunker()).pipe(new NbsFrameDecoder()).pipe(playback)
     return playback
   }
 
-  public _write(frame: NbsFrame, encoding: string, done: Function) {
+  _write(frame: NbsFrame, encoding: string, done: Function) {
     const now = this.clock.performanceNow()
     if (this.firstFrameTimestamp === undefined || this.firstLocalTimestamp === undefined) {
       // This is the first frame we received, use this as reference point.

--- a/src/server/nuclearnet/direct_nuclearnet_client.ts
+++ b/src/server/nuclearnet/direct_nuclearnet_client.ts
@@ -11,39 +11,39 @@ import { NUClearNetClient } from '../../shared/nuclearnet/nuclearnet_client'
  * A thin adapter around the real NUClearNet which implements the NUClearNetClient interface.
  */
 export class DirectNUClearNetClient implements NUClearNetClient {
-  public constructor(private nuclearNetwork: NUClearNet) {
+  constructor(private nuclearNetwork: NUClearNet) {
   }
 
-  public static of(): DirectNUClearNetClient {
+  static of(): DirectNUClearNetClient {
     const nuclearNetwork = new NUClearNet()
     return new DirectNUClearNetClient(nuclearNetwork)
   }
 
-  public connect(options: NUClearNetOptions): () => void {
+  connect(options: NUClearNetOptions): () => void {
     this.nuclearNetwork.connect(options)
     return () => this.nuclearNetwork.disconnect()
   }
 
-  public onJoin(cb: NUClearEventListener): () => void {
+  onJoin(cb: NUClearEventListener): () => void {
     this.nuclearNetwork.on('nuclear_join', cb)
     return () => this.nuclearNetwork.removeListener('nuclear_join', cb)
   }
 
-  public onLeave(cb: NUClearEventListener): () => void {
+  onLeave(cb: NUClearEventListener): () => void {
     this.nuclearNetwork.on('nuclear_leave', cb)
     return () => this.nuclearNetwork.removeListener('nuclear_leave', cb)
   }
 
-  public on(event: string, cb: NUClearPacketListener): () => void {
+  on(event: string, cb: NUClearPacketListener): () => void {
     this.nuclearNetwork.on(event, cb)
     return () => this.nuclearNetwork.removeListener(event, cb)
   }
 
-  public onPacket(cb: NUClearPacketListener): () => void {
+  onPacket(cb: NUClearPacketListener): () => void {
     return this.on('nuclear_packet', cb)
   }
 
-  public send(options: NUClearNetSend): void {
+  send(options: NUClearNetSend): void {
     this.nuclearNetwork.send(options)
   }
 }

--- a/src/server/nuclearnet/fake_nuclearnet_client.ts
+++ b/src/server/nuclearnet/fake_nuclearnet_client.ts
@@ -19,11 +19,11 @@ import { hashType } from './fake_nuclearnet_server'
  * The fake helpers are public, but only should be used by FakeNUClearNetServer.
  */
 export class FakeNUClearNetClient implements NUClearNetClient {
-  public peer: NUClearNetPeer
+  peer: NUClearNetPeer
   private events: EventEmitter
   private connected: boolean
 
-  public constructor(private server: FakeNUClearNetServer) {
+  constructor(private server: FakeNUClearNetServer) {
     this.events = new EventEmitter()
     this.connected = false
   }
@@ -32,11 +32,11 @@ export class FakeNUClearNetClient implements NUClearNetClient {
    * Avoid using this factory in tests as FakeNUClearNetServer.of() is a singleton. You'll get cross-contamination
    * between tests. Simply use the constructor of both FakeNUClearNetServer and FakeNUClearNetClient instead.
    */
-  public static of(): FakeNUClearNetClient {
+  static of(): FakeNUClearNetClient {
     return new FakeNUClearNetClient(FakeNUClearNetServer.of())
   }
 
-  public connect(options: NUClearNetOptions): () => void {
+  connect(options: NUClearNetOptions): () => void {
     this.peer = {
       name: options.name,
       address: '127.0.0.1',
@@ -52,7 +52,7 @@ export class FakeNUClearNetClient implements NUClearNetClient {
     }
   }
 
-  public onJoin(cb: NUClearEventListener): () => void {
+  onJoin(cb: NUClearEventListener): () => void {
     const listener = (peer: NUClearNetPeer) => {
       if (this.connected) {
         cb(peer)
@@ -62,7 +62,7 @@ export class FakeNUClearNetClient implements NUClearNetClient {
     return () => this.events.removeListener('nuclear_join', listener)
   }
 
-  public onLeave(cb: NUClearEventListener): () => void {
+  onLeave(cb: NUClearEventListener): () => void {
     const listener = (peer: NUClearNetPeer) => {
       if (this.connected) {
         cb(peer)
@@ -72,7 +72,7 @@ export class FakeNUClearNetClient implements NUClearNetClient {
     return () => this.events.removeListener('nuclear_leave', listener)
   }
 
-  public on(event: string, cb: NUClearPacketListener): () => void {
+  on(event: string, cb: NUClearPacketListener): () => void {
     const hash = hashType(event).toString('hex')
     const listener = (packet: NUClearNetPacket) => {
       if (this.connected) {
@@ -83,7 +83,7 @@ export class FakeNUClearNetClient implements NUClearNetClient {
     return () => this.events.removeListener(hash, listener)
   }
 
-  public onPacket(cb: NUClearPacketListener): () => void {
+  onPacket(cb: NUClearPacketListener): () => void {
     const listener = (packet: NUClearNetPacket) => {
       if (this.connected) {
         cb(packet)
@@ -93,20 +93,20 @@ export class FakeNUClearNetClient implements NUClearNetClient {
     return () => this.events.removeListener('nuclear_packet', listener)
   }
 
-  public send(options: NUClearNetSend): void {
+  send(options: NUClearNetSend): void {
     this.server.send(this, options)
   }
 
   // Fake helpers, designed only to be used by FakeNUClearNetServer.
-  public fakeJoin(peer: NUClearNetPeer) {
+  fakeJoin(peer: NUClearNetPeer) {
     this.events.emit('nuclear_join', peer)
   }
 
-  public fakeLeave(peer: NUClearNetPeer) {
+  fakeLeave(peer: NUClearNetPeer) {
     this.events.emit('nuclear_leave', peer)
   }
 
-  public fakePacket(hash: string, packet: NUClearNetPacket) {
+  fakePacket(hash: string, packet: NUClearNetPacket) {
     this.events.emit(hash, packet)
     this.events.emit('nuclear_packet', packet)
   }

--- a/src/server/nuclearnet/fake_nuclearnet_server.ts
+++ b/src/server/nuclearnet/fake_nuclearnet_server.ts
@@ -16,7 +16,7 @@ export class FakeNUClearNetServer {
   private events: EventEmitter
   private clients: FakeNUClearNetClient[]
 
-  public constructor() {
+  constructor() {
     this.events = new EventEmitter()
     this.clients = []
   }
@@ -29,11 +29,11 @@ export class FakeNUClearNetServer {
    * Avoid using this singleton factory in tests though, as you'll introduce cross-contamination between tests.
    * Simply use the constructor of both FakeNUClearNetServer and FakeNUClearNetClient instead.
    */
-  public static of = createSingletonFactory(() => {
+  static of = createSingletonFactory(() => {
     return new FakeNUClearNetServer()
   })
 
-  public connect(client: FakeNUClearNetClient): () => void {
+  connect(client: FakeNUClearNetClient): () => void {
     this.events.emit('nuclear_join', client.peer)
     this.clients.push(client)
 
@@ -58,7 +58,7 @@ export class FakeNUClearNetServer {
     }
   }
 
-  public send(client: FakeNUClearNetClient, opts: NUClearNetSend) {
+  send(client: FakeNUClearNetClient, opts: NUClearNetSend) {
     const hash: Buffer = typeof opts.type === 'string' ? hashType(opts.type) : opts.type
     const packet = {
       peer: client.peer,

--- a/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
+++ b/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
@@ -21,11 +21,11 @@ type Opts = {
  * improved to have more intelligent multiplexing.
  */
 export class WebSocketProxyNUClearNetServer {
-  public constructor(private server: WebSocketServer, private nuclearnetClient: NUClearNetClient) {
+  constructor(private server: WebSocketServer, private nuclearnetClient: NUClearNetClient) {
     server.onConnection(this.onClientConnection)
   }
 
-  public static of(server: WebSocketServer, { fakeNetworking }: Opts): WebSocketProxyNUClearNetServer {
+  static of(server: WebSocketServer, { fakeNetworking }: Opts): WebSocketProxyNUClearNetServer {
     const nuclearnetClient: NUClearNetClient = fakeNetworking ? FakeNUClearNetClient.of() : DirectNUClearNetClient.of()
     return new WebSocketProxyNUClearNetServer(server, nuclearnetClient)
   }
@@ -42,7 +42,7 @@ class WebSocketServerClient {
   private offListenMap: Map<string, () => void>
   private processors: Map<NUClearNetPeer, PacketProcessor>
 
-  public constructor(private nuclearnetClient: NUClearNetClient, private socket: WebSocket) {
+  constructor(private nuclearnetClient: NUClearNetClient, private socket: WebSocket) {
     this.connected = false
     this.offJoin = this.nuclearnetClient.onJoin(this.onJoin)
     this.offLeave = this.nuclearnetClient.onLeave(this.onLeave)
@@ -55,7 +55,7 @@ class WebSocketServerClient {
     this.socket.on('disconnect', this.onDisconnect)
   }
 
-  public static of(nuclearNetClient: NUClearNetClient, socket: WebSocket) {
+  static of(nuclearNetClient: NUClearNetClient, socket: WebSocket) {
     return new WebSocketServerClient(nuclearNetClient, socket)
   }
 
@@ -140,11 +140,11 @@ class PacketProcessor {
     this.eventQueueSize = new Map()
   }
 
-  public static of(socket: WebSocket) {
+  static of(socket: WebSocket) {
     return new PacketProcessor(socket, NodeSystemClock, { limit: 1, timeout: 5 })
   }
 
-  public onPacket(event: string, packet: NUClearNetPacket) {
+  onPacket(event: string, packet: NUClearNetPacket) {
     if (packet.reliable) {
       this.sendReliablePacket(event, packet)
     } else if (this.isEventBelowLimit(event)) {

--- a/src/server/nuclearnet/web_socket_server.ts
+++ b/src/server/nuclearnet/web_socket_server.ts
@@ -7,14 +7,14 @@ import * as SocketIO from 'socket.io'
  * There should never be enough logic in here that it needs any testing.
  */
 export class WebSocketServer {
-  public constructor(private sioServer: SocketIO.Namespace) {
+  constructor(private sioServer: SocketIO.Namespace) {
   }
 
-  public static of(server: SocketIO.Namespace) {
+  static of(server: SocketIO.Namespace) {
     return new WebSocketServer(server)
   }
 
-  public onConnection(cb: (socket: WebSocket) => void) {
+  onConnection(cb: (socket: WebSocket) => void) {
     this.sioServer.on('connection', (socket: SocketIO.Socket) => {
       const webSocket = WebSocket.of(socket)
       cb(webSocket)
@@ -23,18 +23,18 @@ export class WebSocketServer {
 }
 
 export class WebSocket {
-  public constructor(private sioSocket: SocketIO.Socket) {
+  constructor(private sioSocket: SocketIO.Socket) {
   }
 
-  public static of(socket: SocketIO.Socket) {
+  static of(socket: SocketIO.Socket) {
     return new WebSocket(socket)
   }
 
-  public on(event: string, cb: (...args: any[]) => void) {
+  on(event: string, cb: (...args: any[]) => void) {
     this.sioSocket.on(event, cb)
   }
 
-  public send(event: string, ...args: any[]) {
+  send(event: string, ...args: any[]) {
     this.sioSocket.emit(event, ...args)
   }
 }

--- a/src/shared/base/random/seeded_random.ts
+++ b/src/shared/base/random/seeded_random.ts
@@ -6,22 +6,22 @@ import * as seedrandom from 'seedrandom'
  * Useful in tests or fakes to generate a predictable range of values that will be the same each time the test is run.
  */
 export class SeededRandom {
-  public constructor(private prng: () => number) {
+  constructor(private prng: () => number) {
   }
 
-  public static of(seed: string) {
+  static of(seed: string) {
     return new SeededRandom(seedrandom(seed))
   }
 
-  public float(): number {
+  float(): number {
     return this.prng()
   }
 
-  public integer(min: number, max: number): number {
+  integer(min: number, max: number): number {
     return Math.floor(this.prng() * (max - min) + min)
   }
 
-  public choice<T>(arr: T[]): T {
+  choice<T>(arr: T[]): T {
     const index = this.integer(0, arr.length)
     return arr[index]
   }

--- a/src/shared/base/testing/tests/create_mock_event_handler.tests.ts
+++ b/src/shared/base/testing/tests/create_mock_event_handler.tests.ts
@@ -33,7 +33,7 @@ describe('createMockEventHandler', () => {
 type TestEventListener = (str: string, num: number) => void
 
 class TestClass {
-  public onTestEvent(callback: TestEventListener): () => void {
+  onTestEvent(callback: TestEventListener): () => void {
     return () => {
     }
   }

--- a/src/shared/field/dimensions.ts
+++ b/src/shared/field/dimensions.ts
@@ -18,20 +18,20 @@ interface FieldModelValues {
 }
 
 export class FieldDimensions {
-  @observable public lineWidth: number
-  @observable public markWidth: number
-  @observable public fieldLength: number
-  @observable public fieldWidth: number
-  @observable public goalDepth: number
-  @observable public goalWidth: number
-  @observable public goalAreaLength: number
-  @observable public goalAreaWidth: number
-  @observable public goalCrossbarHeight: number
-  @observable public goalPostDiameter: number
-  @observable public goalNetHeight: number
-  @observable public penaltyMarkDistance: number
-  @observable public centerCircleDiameter: number
-  @observable public borderStripMinWidth: number
+  @observable lineWidth: number
+  @observable markWidth: number
+  @observable fieldLength: number
+  @observable fieldWidth: number
+  @observable goalDepth: number
+  @observable goalWidth: number
+  @observable goalAreaLength: number
+  @observable goalAreaWidth: number
+  @observable goalCrossbarHeight: number
+  @observable goalPostDiameter: number
+  @observable goalNetHeight: number
+  @observable penaltyMarkDistance: number
+  @observable centerCircleDiameter: number
+  @observable borderStripMinWidth: number
 
   constructor(values: FieldModelValues) {
     this.lineWidth = values.lineWidth
@@ -50,7 +50,7 @@ export class FieldDimensions {
     this.borderStripMinWidth = values.borderStripMinWidth
   }
 
-  public static preYear2014() {
+  static preYear2014() {
     return new FieldDimensions({
       lineWidth: 0.05,
       markWidth: 0.1,
@@ -69,7 +69,7 @@ export class FieldDimensions {
     })
   }
 
-  public static postYear2017() {
+  static postYear2017() {
     return new FieldDimensions({
       lineWidth: 0.06,
       markWidth: 0.1,

--- a/src/shared/time/fake_clock.ts
+++ b/src/shared/time/fake_clock.ts
@@ -15,47 +15,47 @@ export class FakeClock implements Clock {
   private time: number
   private tasks: Task[]
 
-  public constructor(time: number) {
+  constructor(time: number) {
     this.nextId = 0
     this.time = time
     this.tasks = []
   }
 
-  public static of(time: number = 0) {
+  static of(time: number = 0) {
     return new FakeClock(time)
   }
 
-  public now(): number {
+  now(): number {
     return this.time
   }
 
-  public date(): Date {
+  date(): Date {
     return new Date(this.now() * SecondsToMilliseconds)
   }
 
-  public performanceNow(): number {
+  performanceNow(): number {
     return this.time
   }
 
-  public setTimeout(fn: () => void, seconds: number): CancelTimer {
+  setTimeout(fn: () => void, seconds: number): CancelTimer {
     const id = this.nextId++
     this.addTask({ id, nextTime: this.now() + seconds, fn })
     return () => this.removeTask(id)
   }
 
-  public setInterval(fn: () => void, seconds: number): CancelTimer {
+  setInterval(fn: () => void, seconds: number): CancelTimer {
     const id = this.nextId++
     this.addTask({ id, nextTime: this.now() + seconds, period: seconds, fn })
     return () => this.removeTask(id)
   }
 
-  public nextTick(fn: () => void): CancelTimer {
+  nextTick(fn: () => void): CancelTimer {
     const id = this.nextId++
     this.addTask({ id, nextTime: this.now() + Number.MIN_VALUE, fn })
     return () => this.removeTask(id)
   }
 
-  public tick(delta: number = 1): void {
+  tick(delta: number = 1): void {
     const newTime = this.now() + delta
 
     while (this.tasks.length > 0 && this.tasks[0].nextTime <= newTime) {
@@ -66,7 +66,7 @@ export class FakeClock implements Clock {
     this.time = newTime
   }
 
-  public runAllTimers(): void {
+  runAllTimers(): void {
     const limit = 1000
     let i = 0
 
@@ -80,7 +80,7 @@ export class FakeClock implements Clock {
     }
   }
 
-  public runOnlyPendingTimers(): void {
+  runOnlyPendingTimers(): void {
     const limit = 1000
     let i = 0
 
@@ -96,7 +96,7 @@ export class FakeClock implements Clock {
     }
   }
 
-  public runTimersToTime(time: number): void {
+  runTimersToTime(time: number): void {
     const limit = 1000
     let i = 0
 

--- a/src/virtual_robots/simulators/overview_simulator.ts
+++ b/src/virtual_robots/simulators/overview_simulator.ts
@@ -17,14 +17,14 @@ export class OverviewSimulator implements Simulator {
               private random: SeededRandom) {
   }
 
-  public static of() {
+  static of() {
     return new OverviewSimulator(
       FieldDimensions.postYear2017(),
       SeededRandom.of('overview_simulator'),
     )
   }
 
-  public simulate(time: number, index: number, numRobots: number): Message[] {
+  simulate(time: number, index: number, numRobots: number): Message[] {
     const messageType = 'message.support.nubugger.Overview'
 
     const t = time / 10 - index

--- a/src/virtual_robots/simulators/sensor_data_simulator.ts
+++ b/src/virtual_robots/simulators/sensor_data_simulator.ts
@@ -11,11 +11,11 @@ import Sensors = message.input.Sensors
 export const HIP_TO_FOOT = 0.2465
 
 export class SensorDataSimulator implements Simulator {
-  public static of() {
+  static of() {
     return new SensorDataSimulator()
   }
 
-  public simulate(time: number, index: number, numRobots: number): Message[] {
+  simulate(time: number, index: number, numRobots: number): Message[] {
     const messageType = 'message.input.Sensors'
 
     // Simulate a walk

--- a/src/virtual_robots/virtual_robot.ts
+++ b/src/virtual_robots/virtual_robot.ts
@@ -29,13 +29,13 @@ export class VirtualRobot {
     this.simulators = opts.simulators
   }
 
-  public static of(opts: Opts): VirtualRobot {
+  static of(opts: Opts): VirtualRobot {
     const network = opts.fakeNetworking ? FakeNUClearNetClient.of() : DirectNUClearNetClient.of()
     const clock = NodeSystemClock
     return new VirtualRobot(network, clock, opts)
   }
 
-  public startSimulators(index: number, numRobots: number) {
+  startSimulators(index: number, numRobots: number) {
     const disconnect = this.connect()
 
     const stops = this.simulators.map(opts => {
@@ -49,7 +49,7 @@ export class VirtualRobot {
     }
   }
 
-  public send(messageType: string, buffer: Uint8Array, reliable?: boolean) {
+  send(messageType: string, buffer: Uint8Array, reliable?: boolean) {
     this.network.send({
       type: messageType,
       payload: new Buffer(buffer),
@@ -58,13 +58,13 @@ export class VirtualRobot {
     })
   }
 
-  public simulateAll(index: number, numRobots: number) {
+  simulateAll(index: number, numRobots: number) {
     const messages = flatMap(opts => opts.simulator.simulate(this.clock.now(), index, numRobots), this.simulators)
     messages.forEach(message => this.send(message.messageType, message.buffer))
     return messages
   }
 
-  public connect(): () => void {
+  connect(): () => void {
     return this.network.connect({ name: this.name })
   }
 

--- a/src/virtual_robots/virtual_robots.ts
+++ b/src/virtual_robots/virtual_robots.ts
@@ -12,11 +12,11 @@ type Opts = {
 export class VirtualRobots {
   private robots: VirtualRobot[]
 
-  public constructor(opts: { robots: VirtualRobot[] }) {
+  constructor(opts: { robots: VirtualRobot[] }) {
     this.robots = opts.robots
   }
 
-  public static of(opts: Opts): VirtualRobots {
+  static of(opts: Opts): VirtualRobots {
     const robots = range(opts.numRobots).map(index => VirtualRobot.of({
       fakeNetworking: opts.fakeNetworking,
       name: `Virtual Robot #${index + 1}`,
@@ -25,16 +25,16 @@ export class VirtualRobots {
     return new VirtualRobots({ robots })
   }
 
-  public startSimulators(): () => void {
+  startSimulators(): () => void {
     const stops = this.robots.map((robot, index) => robot.startSimulators(index, this.robots.length))
     return () => stops.forEach(stop => stop())
   }
 
-  public simulateAll(): void {
+  simulateAll(): void {
     this.robots.forEach((robot, index) => robot.simulateAll(index, this.robots.length))
   }
 
-  public connect(): void {
+  connect(): void {
     this.robots.forEach(robot => robot.connect())
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -29,20 +29,8 @@
     "interface-over-type-literal": false,
     "linebreak-style": "LF",
     "max-classes-per-file": false,
-    "member-access": true,
-    "member-ordering": [
-      true,
-      {
-        "order": [
-          "instance-field",
-          "constructor",
-          "static-method",
-          "public-instance-method",
-          "protected-instance-method",
-          "private-instance-method"
-        ]
-      }
-    ],
+    "member-access": [true, "no-public"],
+    "member-ordering": false,
     "new-parens": true,
     "no-bitwise": false,
     "no-conditional-assignment": true,


### PR DESCRIPTION
This PR

1. Removes member ordering restrictions, allowing a more flexible/sensible code structure.
2. Removes `public` accessors and assumes it to be the default. So much less typing to do!

Any merge conflicts with existing PRs should be easy to resolve by cherry picking `
7d0dd58` and running `yarn tslint:fix` before merging:

```
git cherry-pick -n 7d0dd58
yarn tslint:fix
git commit -a -m 'remove public accessors'
git fetch origin
git merge origin/master
```