### PR TITLE
[WIP] NUClearNet streams

### DIFF
--- a/src/client/nuclearnet/web_socket_proxy_nuclearnet_client.ts
+++ b/src/client/nuclearnet/web_socket_proxy_nuclearnet_client.ts
@@ -88,7 +88,9 @@ export class WebSocketProxyNUClearNetClient implements NUClearNetClient {
     const listener = (packet: NUClearNetPacket, ack?: () => void) => {
       cb(packet)
       if (ack) {
-        ack()
+        setTimeout(() => {
+          ack()
+        }, 500)
       }
     }
     this.socket.on(event, listener)

--- a/src/server/nbs/nuclearnet_stream.ts
+++ b/src/server/nbs/nuclearnet_stream.ts
@@ -1,6 +1,13 @@
+import { NUClearNetPeer } from 'nuclearnet.js'
 import { NUClearNetPacket } from 'nuclearnet.js'
 import * as stream from 'stream'
 import { NUClearNetClient } from '../../shared/nuclearnet/nuclearnet_client'
+
+type StreamEvent = StreamPacket | StreamJoinEvent | StreamLeaveEvent
+
+type StreamPacket = { type: 'packet', packet: NUClearNetPacket }
+type StreamJoinEvent = { type: 'nuclear_join', peer: NUClearNetPeer }
+type StreamLeaveEvent = { type: 'nuclear_leave', peer: NUClearNetPeer }
 
 export class NUClearNetStream extends stream.Duplex {
   constructor(private nuclearnetClient: NUClearNetClient) {
@@ -8,6 +15,12 @@ export class NUClearNetStream extends stream.Duplex {
       objectMode: true,
     })
     nuclearnetClient.onPacket(this.onPacket);
+    nuclearnetClient.onJoin(this.onJoin);
+    nuclearnetClient.onLeave(this.onLeave);
+  }
+
+  push(event: StreamEvent | null): boolean {
+    return super.push(event);
   }
 
   public static of(nuclearnetClient: NUClearNetClient) {
@@ -15,14 +28,22 @@ export class NUClearNetStream extends stream.Duplex {
   }
 
   onPacket = (packet: NUClearNetPacket) => {
-    this.push({ event: 'packet', packet });
+    this.push({ type: 'packet', packet });
+  }
+
+  onJoin = (peer: NUClearNetPeer) => {
+    this.push({ type: 'nuclear_join', peer })
+  }
+
+  onLeave = (peer: NUClearNetPeer) => {
+    this.push({ type: 'nuclear_leave', peer })
   }
 
   _read() {
-    // TODO
+    // TODO (Annable): Is an empty implementation fine?
   }
 
-  // TODO: end when client disconnects?
+  // TODO (Annable): Automatically end when client disconnects?
   end() {
     this.push(null);
   }

--- a/src/server/nbs/nuclearnet_stream.ts
+++ b/src/server/nbs/nuclearnet_stream.ts
@@ -1,0 +1,29 @@
+import { NUClearNetPacket } from 'nuclearnet.js'
+import * as stream from 'stream'
+import { NUClearNetClient } from '../../shared/nuclearnet/nuclearnet_client'
+
+export class NUClearNetStream extends stream.Duplex {
+  constructor(private nuclearnetClient: NUClearNetClient) {
+    super({
+      objectMode: true,
+    })
+    nuclearnetClient.onPacket(this.onPacket);
+  }
+
+  public static of(nuclearnetClient: NUClearNetClient) {
+    return new NUClearNetStream(nuclearnetClient)
+  }
+
+  onPacket = (packet: NUClearNetPacket) => {
+    this.push({ event: 'packet', packet });
+  }
+
+  _read() {
+    // TODO
+  }
+
+  // TODO: end when client disconnects?
+  end() {
+    this.push(null);
+  }
+}

--- a/src/server/nbs/nuclearnet_stream.ts
+++ b/src/server/nbs/nuclearnet_stream.ts
@@ -9,42 +9,69 @@ export type StreamJoinEvent = { type: 'nuclear_join', peer: NUClearNetPeer }
 export type StreamLeaveEvent = { type: 'nuclear_leave', peer: NUClearNetPeer }
 
 export class NUClearNetStream extends stream.Readable {
-  constructor(private nuclearnetClient: NUClearNetClient) {
+  private buffer: StreamPacket[] = []
+  private buffering = false
+
+  constructor(private nuclearnetClient: NUClearNetClient, private highWaterMark: number = 16) {
     super({
       objectMode: true,
+      highWaterMark,
     })
     nuclearnetClient.onPacket(this.onPacket)
     nuclearnetClient.onJoin(this.onJoin)
     nuclearnetClient.onLeave(this.onLeave)
   }
 
-  public static of(nuclearnetClient: NUClearNetClient) {
-    return new NUClearNetStream(nuclearnetClient)
+  public static of(nuclearnetClient: NUClearNetClient, highWaterMark: number) {
+    return new NUClearNetStream(nuclearnetClient, highWaterMark)
   }
 
-  push(event: StreamEvent | null): boolean {
+  public push(event: StreamEvent | null): boolean {
     return super.push(event)
   }
 
-  onPacket = (packet: NUClearNetPacket) => {
-    this.push({ type: 'packet', packet })
+  private bufferEvent(event: StreamPacket) {
+    this.buffer.push(event)
   }
 
-  onJoin = (peer: NUClearNetPeer) => {
+  private onDrain = () => {
+    this.buffering = false
+    while (this.buffer.length > 0) {
+      const event = this.buffer.shift()!
+      if (!this.onPacket(event.packet)) {
+        break
+      }
+    }
+  }
+
+  private onPacket = (packet: NUClearNetPacket): boolean => {
+    const event: StreamPacket = { type: 'packet', packet }
+    if (this.buffering) {
+      this.bufferEvent(event)
+      return false
+    } else if (!this.push(event)) {
+      this.buffering = true
+      return false
+    }
+    return true
+  }
+
+  private onJoin = (peer: NUClearNetPeer) => {
     this.push({ type: 'nuclear_join', peer })
   }
 
-  onLeave = (peer: NUClearNetPeer) => {
+  private onLeave = (peer: NUClearNetPeer) => {
     this.push({ type: 'nuclear_leave', peer })
   }
 
-  _read() {
-    // TODO (Annable): Is an empty implementation fine?
-    // Intentionally empty
+  public _read(size: number) {
+    if (this.buffering) {
+      this.onDrain()
+    }
   }
 
   // TODO (Annable): Automatically end when client disconnects?
-  end() {
+  public end() {
     this.push(null)
   }
 }
@@ -65,7 +92,7 @@ export class PeerFilter extends stream.Transform {
   }
 
   write(event: StreamEvent) {
-    return super.write(event);
+    return super.write(event)
   }
 
   _transform(event: StreamEvent, encoding: string, done: (err?: any, data?: any) => void) {

--- a/src/server/nbs/nuclearnet_stream.ts
+++ b/src/server/nbs/nuclearnet_stream.ts
@@ -3,32 +3,31 @@ import { NUClearNetPacket } from 'nuclearnet.js'
 import * as stream from 'stream'
 import { NUClearNetClient } from '../../shared/nuclearnet/nuclearnet_client'
 
-type StreamEvent = StreamPacket | StreamJoinEvent | StreamLeaveEvent
+export type StreamEvent = StreamPacket | StreamJoinEvent | StreamLeaveEvent
+export type StreamPacket = { type: 'packet', packet: NUClearNetPacket }
+export type StreamJoinEvent = { type: 'nuclear_join', peer: NUClearNetPeer }
+export type StreamLeaveEvent = { type: 'nuclear_leave', peer: NUClearNetPeer }
 
-type StreamPacket = { type: 'packet', packet: NUClearNetPacket }
-type StreamJoinEvent = { type: 'nuclear_join', peer: NUClearNetPeer }
-type StreamLeaveEvent = { type: 'nuclear_leave', peer: NUClearNetPeer }
-
-export class NUClearNetStream extends stream.Duplex {
+export class NUClearNetStream extends stream.Readable {
   constructor(private nuclearnetClient: NUClearNetClient) {
     super({
       objectMode: true,
     })
-    nuclearnetClient.onPacket(this.onPacket);
-    nuclearnetClient.onJoin(this.onJoin);
-    nuclearnetClient.onLeave(this.onLeave);
-  }
-
-  push(event: StreamEvent | null): boolean {
-    return super.push(event);
+    nuclearnetClient.onPacket(this.onPacket)
+    nuclearnetClient.onJoin(this.onJoin)
+    nuclearnetClient.onLeave(this.onLeave)
   }
 
   public static of(nuclearnetClient: NUClearNetClient) {
     return new NUClearNetStream(nuclearnetClient)
   }
 
+  push(event: StreamEvent | null): boolean {
+    return super.push(event)
+  }
+
   onPacket = (packet: NUClearNetPacket) => {
-    this.push({ type: 'packet', packet });
+    this.push({ type: 'packet', packet })
   }
 
   onJoin = (peer: NUClearNetPeer) => {
@@ -41,10 +40,46 @@ export class NUClearNetStream extends stream.Duplex {
 
   _read() {
     // TODO (Annable): Is an empty implementation fine?
+    // Intentionally empty
   }
 
   // TODO (Annable): Automatically end when client disconnects?
   end() {
-    this.push(null);
+    this.push(null)
+  }
+}
+
+export class PeerFilter extends stream.Transform {
+  constructor(private peer: NUClearNetPeer) {
+    super({
+      objectMode: true,
+    })
+  }
+
+  static of(peer: NUClearNetPeer) {
+    return new PeerFilter(peer)
+  }
+
+  push(event: StreamEvent | null): boolean {
+    return super.push(event)
+  }
+
+  write(event: StreamEvent) {
+    return super.write(event);
+  }
+
+  _transform(event: StreamEvent, encoding: string, done: (err?: any, data?: any) => void) {
+    if (event.type !== 'packet' || this.isPeer(event.packet.peer)) {
+      this.push(event)
+    }
+    done()
+  }
+
+  isPeer(otherPeer: NUClearNetPeer) {
+    return (
+      otherPeer.name === this.peer.name
+      && otherPeer.address === this.peer.address
+      && otherPeer.port === this.peer.port
+    )
   }
 }

--- a/src/server/nbs/tests/nuclearnet_stream.tests.ts
+++ b/src/server/nbs/tests/nuclearnet_stream.tests.ts
@@ -1,0 +1,32 @@
+import { FakeNUClearNetClient } from '../../nuclearnet/fake_nuclearnet_client'
+import { FakeNUClearNetServer } from '../../nuclearnet/fake_nuclearnet_server'
+import { NUClearNetStream } from '../nuclearnet_stream'
+
+describe('NUClearNetStream', () => {
+  let nuclearnetServer: FakeNUClearNetServer
+  let nuclearnetClient: FakeNUClearNetClient
+  let stream: NUClearNetStream
+
+  beforeEach(() => {
+    nuclearnetServer = new FakeNUClearNetServer()
+    nuclearnetClient = new FakeNUClearNetClient(nuclearnetServer)
+    stream = NUClearNetStream.of(nuclearnetClient)
+  })
+
+  it('forwards packets into the stream', done => {
+    const spy = jest.fn()
+    const packet = {
+      peer: { name: 'alice', address: 'fake_address', port: -1 },
+      hash: new Buffer(8),
+      payload: new Buffer(8),
+      reliable: true,
+    }
+    stream.on('data', spy).on('end', () => {
+      expect(spy).toHaveBeenCalledWith({ event: 'packet', packet })
+      done()
+    })
+    nuclearnetClient.connect({ name: 'bob' })
+    nuclearnetClient.fakePacket('hash', packet)
+    stream.end()
+  })
+})

--- a/src/server/nbs/tests/nuclearnet_stream.tests.ts
+++ b/src/server/nbs/tests/nuclearnet_stream.tests.ts
@@ -4,6 +4,8 @@ import { PassThrough } from 'stream'
 import { range } from '../../../shared/base/range'
 import { FakeNUClearNetClient } from '../../nuclearnet/fake_nuclearnet_client'
 import { FakeNUClearNetServer } from '../../nuclearnet/fake_nuclearnet_server'
+import { StreamDisconnectEvent } from '../nuclearnet_stream'
+import { StreamConnectEvent } from '../nuclearnet_stream'
 import { StreamPacket } from '../nuclearnet_stream'
 import { PeerFilter } from '../nuclearnet_stream'
 import { NUClearNetStream } from '../nuclearnet_stream'
@@ -120,6 +122,31 @@ describe('NUClearNetStream', () => {
       await flush()
 
       stream.end()
+    })
+
+    it('forwards connect messages from stream', () => {
+      jest.spyOn(nuclearnetClient, 'connect')
+      const event: StreamConnectEvent = {
+        type: 'nuclear_connect',
+        options: {
+          name: 'bob'
+        }
+      }
+      stream.write(event);
+      expect(nuclearnetClient.connect).toHaveBeenCalled()
+    })
+
+    it('forwards disconnect messages from stream', async () => {
+      const disconnect = jest.fn()
+      jest.spyOn(nuclearnetClient, 'connect').mockImplementation(() => disconnect)
+      const connectEvent: StreamConnectEvent = {
+        type: 'nuclear_connect',
+        options: { name: 'bob' }
+      }
+      stream.write(connectEvent);
+      const disconnectEvent: StreamDisconnectEvent = { type: 'nuclear_disconnect' }
+      stream.write(disconnectEvent);
+      expect(disconnect).toHaveBeenCalled()
     })
   })
 })

--- a/src/server/nbs/tests/nuclearnet_stream.tests.ts
+++ b/src/server/nbs/tests/nuclearnet_stream.tests.ts
@@ -26,7 +26,8 @@ describe('NUClearNetStream', () => {
     const spy = jest.fn()
     stream.on('data', spy).on('end', () => {
       expect(spy).toHaveBeenCalledWith({
-        type: 'nuclear_join', peer: expect.objectContaining({
+        type: 'nuclear_join',
+        data: expect.objectContaining({
           name: 'alice',
         }),
       })
@@ -44,7 +45,8 @@ describe('NUClearNetStream', () => {
     const spy = jest.fn()
     stream.on('data', spy).on('end', () => {
       expect(spy).toHaveBeenCalledWith({
-        type: 'nuclear_leave', peer: expect.objectContaining({
+        type: 'nuclear_leave',
+        data: expect.objectContaining({
           name: 'alice',
         }),
       })
@@ -68,7 +70,7 @@ describe('NUClearNetStream', () => {
       reliable: true,
     }
     stream.on('data', spy).on('end', () => {
-      expect(spy).toHaveBeenCalledWith({ type: 'packet', packet })
+      expect(spy).toHaveBeenCalledWith({ type: 'packet', data: packet })
       done()
     })
     nuclearnetClient.connect({ name: 'bob' })
@@ -109,7 +111,7 @@ describe('NUClearNetStream', () => {
         const packetEventCalls = spy.mock.calls.filter(call => call[0].type === 'packet')
         expect(packetEventCalls.length).toBe(100)
         packetEventCalls.forEach(call => {
-          expect(call[0]).toMatchObject({ type: 'packet', packet })
+          expect(call[0]).toMatchObject({ type: 'packet', data: packet })
         })
         done()
       })
@@ -128,11 +130,11 @@ describe('NUClearNetStream', () => {
       jest.spyOn(nuclearnetClient, 'connect')
       const event: StreamConnectEvent = {
         type: 'nuclear_connect',
-        options: {
-          name: 'bob'
-        }
+        data: {
+          name: 'bob',
+        },
       }
-      stream.write(event);
+      stream.write(event)
       expect(nuclearnetClient.connect).toHaveBeenCalled()
     })
 
@@ -141,11 +143,11 @@ describe('NUClearNetStream', () => {
       jest.spyOn(nuclearnetClient, 'connect').mockImplementation(() => disconnect)
       const connectEvent: StreamConnectEvent = {
         type: 'nuclear_connect',
-        options: { name: 'bob' }
+        data: { name: 'bob' },
       }
-      stream.write(connectEvent);
-      const disconnectEvent: StreamDisconnectEvent = { type: 'nuclear_disconnect' }
-      stream.write(disconnectEvent);
+      stream.write(connectEvent)
+      const disconnectEvent: StreamDisconnectEvent = { type: 'nuclear_disconnect', data: undefined }
+      stream.write(disconnectEvent)
       expect(disconnect).toHaveBeenCalled()
     })
   })
@@ -170,7 +172,7 @@ describe('PeerFilter', () => {
     })
     const event: StreamPacket = {
       type: 'packet',
-      packet: {
+      data: {
         peer: { name: 'bob', address: 'fake_address', port: -1 },
         hash: new Buffer(8),
         payload: new Buffer(8),
@@ -189,7 +191,7 @@ describe('PeerFilter', () => {
     })
     const event: StreamPacket = {
       type: 'packet',
-      packet: {
+      data: {
         peer: { name: 'alice', address: 'fake_address', port: -1 },
         hash: new Buffer(8),
         payload: new Buffer(8),

--- a/src/server/nbs/tests/nuclearnet_stream.tests.ts
+++ b/src/server/nbs/tests/nuclearnet_stream.tests.ts
@@ -1,4 +1,7 @@
+import { NUClearNetPacket } from 'nuclearnet.js'
 import { NUClearNetPeer } from 'nuclearnet.js'
+import { PassThrough } from 'stream'
+import { range } from '../../../shared/base/range'
 import { FakeNUClearNetClient } from '../../nuclearnet/fake_nuclearnet_client'
 import { FakeNUClearNetServer } from '../../nuclearnet/fake_nuclearnet_server'
 import { StreamPacket } from '../nuclearnet_stream'
@@ -6,6 +9,7 @@ import { PeerFilter } from '../nuclearnet_stream'
 import { NUClearNetStream } from '../nuclearnet_stream'
 
 describe('NUClearNetStream', () => {
+  const highWaterMark = 10
   let nuclearnetServer: FakeNUClearNetServer
   let nuclearnetClient: FakeNUClearNetClient
   let stream: NUClearNetStream
@@ -13,7 +17,7 @@ describe('NUClearNetStream', () => {
   beforeEach(() => {
     nuclearnetServer = new FakeNUClearNetServer()
     nuclearnetClient = new FakeNUClearNetClient(nuclearnetServer)
-    stream = NUClearNetStream.of(nuclearnetClient)
+    stream = NUClearNetStream.of(nuclearnetClient, highWaterMark)
   })
 
   it('forwards join events into the stream', done => {
@@ -69,7 +73,58 @@ describe('NUClearNetStream', () => {
     nuclearnetClient.fakePacket('hash', packet)
     stream.end()
   })
+
+  describe('buffering', () => {
+    let packet: NUClearNetPacket
+
+    beforeEach(() => {
+      packet = {
+        peer: { name: 'alice', address: 'fake_address', port: -1 },
+        hash: new Buffer(8),
+        payload: new Buffer(8),
+        reliable: true,
+      }
+      nuclearnetClient.connect({ name: 'bob' })
+    })
+
+    it('stops at highwatermark', done => {
+      const spy = jest.fn()
+      stream.on('data', spy).on('end', () => {
+        expect(spy).toHaveBeenCalledTimes(highWaterMark)
+        done()
+      })
+      range(highWaterMark + 10).forEach(() => {
+        nuclearnetClient.fakePacket('hash', packet)
+      })
+      stream.end()
+    })
+
+    it('drains buffer when available', async done => {
+      const slowReader = new PassThrough({ objectMode: true })
+      const spy = jest.fn()
+
+      slowReader.on('data', spy).on('end', () => {
+        const packetEventCalls = spy.mock.calls.filter(call => call[0].type === 'packet')
+        expect(packetEventCalls.length).toBe(100)
+        packetEventCalls.forEach(call => {
+          expect(call[0]).toMatchObject({ type: 'packet', packet })
+        })
+        done()
+      })
+      stream.pipe(slowReader)
+
+      range(highWaterMark + 90).forEach(() => {
+        nuclearnetClient.fakePacket('hash', packet)
+      })
+
+      await flush()
+
+      stream.end()
+    })
+  })
 })
+
+const flush = () => new Promise(res => setImmediate(res))
 
 describe('PeerFilter', () => {
   let peer: NUClearNetPeer

--- a/src/server/nuclearnet/tests/web_socket_proxy_nuclearnet_server.tests.ts
+++ b/src/server/nuclearnet/tests/web_socket_proxy_nuclearnet_server.tests.ts
@@ -29,19 +29,21 @@ describe('WebSocketProxyNUClearNetServer', () => {
     expect(webSocketServer.onConnection).toHaveBeenCalledTimes(1)
   })
 
-  it('forwards NUClearNet network join events to socket', () => {
+  it('forwards NUClearNet network join events to socket', async () => {
     const webSocket = createMockInstance(WebSocket)
     onClientConnection.mockEvent(webSocket)
 
     const alice = new FakeNUClearNetClient(nuclearnetServer)
     alice.connect({ name: 'alice' })
 
+    await flush()
+
     expect(webSocket.send).toHaveBeenLastCalledWith('nuclear_join', expect.objectContaining({
       name: 'alice',
     }))
   })
 
-  it('forwards NUClearNet network leave events to socket', () => {
+  it('forwards NUClearNet network leave events to socket', async () => {
     const webSocket = createMockInstance(WebSocket)
     onClientConnection.mockEvent(webSocket)
 
@@ -49,8 +51,13 @@ describe('WebSocketProxyNUClearNetServer', () => {
     const disconnect = alice.connect({ name: 'alice' })
     disconnect()
 
+    await flush()
+
     expect(webSocket.send).toHaveBeenLastCalledWith('nuclear_leave', expect.objectContaining({
       name: 'alice',
     }))
   })
 })
+
+
+const flush = () => new Promise(res => setImmediate(res))

--- a/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
+++ b/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
@@ -4,6 +4,9 @@ import { NUClearNetPacket } from 'nuclearnet.js'
 
 import { NUClearNetClient } from '../../shared/nuclearnet/nuclearnet_client'
 import { Clock } from '../../shared/time/clock'
+import { WebSocketStream } from '../nbs/nuclearnet_stream'
+import { PeerFilter } from '../nbs/nuclearnet_stream'
+import { NUClearNetStream } from '../nbs/nuclearnet_stream'
 import { NodeSystemClock } from '../time/node_clock'
 
 import { DirectNUClearNetClient } from './direct_nuclearnet_client'
@@ -31,7 +34,11 @@ export class WebSocketProxyNUClearNetServer {
   }
 
   private onClientConnection = (socket: WebSocket) => {
-    WebSocketServerClient.of(this.nuclearnetClient, socket)
+    const nuclearStream = NUClearNetStream.of(this.nuclearnetClient)
+    const socketStream = WebSocketStream.of(socket)
+    nuclearStream.pipe(socketStream)
+    socketStream.pipe(nuclearStream)
+    // WebSocketServerClient.of(this.nuclearnetClient, socket)
   }
 }
 

--- a/src/server/nuclearnet/web_socket_server.ts
+++ b/src/server/nuclearnet/web_socket_server.ts
@@ -37,4 +37,8 @@ export class WebSocket {
   public send(event: string, ...args: any[]) {
     this.sioSocket.emit(event, ...args)
   }
+
+  public sendVolatile(event: string, ...args: any[]) {
+    this.sioSocket.volatile.emit(event, ...args)
+  }
 }


### PR DESCRIPTION
The intention of this PR is to harness the inbuilt backpressure feature of node streams, such that a slower browser connection would also slow down the websocket, such that we can simply pipe a `NUClearNetStream` to a `WebSocketStream` and compose them with whatever other streams we might find useful.