### PR TITLE
Fix production and node gyp having overlapping build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .DS_Store
-node_modules
+/node_modules
 .module-cache
-build
+/build
+/dist
 
 # IntelliJ IDEA
 /.idea/workspace.xml

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "virtual-robots": "nodemon ./src/virtual_robots/run.ts",
     "prod": "ts-node ./src/server/prod.ts",
     "prod:virtual": "ts-node ./src/server/prod.ts --virtual-robots",
-    "build": "yarn clean:build && webpack -p --progress --colors",
-    "clean": "yarn clean:build && yarn clean:coverage",
-    "clean:build": "rimraf build",
+    "build": "yarn clean:dist && webpack -p --progress --colors",
+    "clean": "yarn clean:dist && yarn clean:coverage",
+    "clean:dist": "rimraf dist",
     "clean:coverage": "rimraf coverage",
     "heroku-postbuild": "yarn build",
     "prepush": "yarn tslint"

--- a/src/server/prod.ts
+++ b/src/server/prod.ts
@@ -11,6 +11,10 @@ import { OverviewSimulator } from '../virtual_robots/simulators/overview_simulat
 import { SensorDataSimulator } from '../virtual_robots/simulators/sensor_data_simulator'
 import { VirtualRobots } from '../virtual_robots/virtual_robots'
 
+import { NBSPlayer } from './nbs/mmap_nbs_player/nbs_player'
+import { NBSPacket } from './nbs/mmap_nbs_player/nbs_player'
+import { DirectNUClearNetClient } from './nuclearnet/direct_nuclearnet_client'
+import { FakeNUClearNetClient } from './nuclearnet/fake_nuclearnet_client'
 import { WebSocketProxyNUClearNetServer } from './nuclearnet/web_socket_proxy_nuclearnet_server'
 import { WebSocketServer } from './nuclearnet/web_socket_server'
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -7,7 +7,7 @@ import Devtool = webpack.Options.Devtool
 
 const isProduction = process.argv.indexOf('-p') >= 0
 const sourcePath = path.join(__dirname, './src')
-const outPath = path.join(__dirname, './build')
+const outPath = path.join(__dirname, './dist')
 
 const devtool: Devtool = isProduction ? 'source-map' : 'inline-source-map'
 


### PR DESCRIPTION
The c++ bindings and prod had overlapping folders and were deleting eachother.
This moves the production build from `build` to `dist`