### PR TITLE
Allows for NBS Player to compile on Windows

### DIFF
--- a/src/server/nbs/mmap_nbs_player/nbs_player.cpp
+++ b/src/server/nbs/mmap_nbs_player/nbs_player.cpp
@@ -64,9 +64,9 @@ void NBSPlayer::build_index() {
         int lock = 3;
         while (lock && p < map.size()) {
             switch (lock) {
-                case 3: lock = reinterpret_cast<uint8_t>(map[p++]) == 0xE2 ? 2 : 3; break;
-                case 2: lock = reinterpret_cast<uint8_t>(map[p++]) == 0x98 ? 1 : 3; break;
-                case 1: lock = reinterpret_cast<uint8_t>(map[p++]) == 0xA2 ? 0 : 3; break;
+                case 3: lock = reinterpret_cast<uint8_t&>(map[p++]) == 0xE2 ? 2 : 3; break;
+                case 2: lock = reinterpret_cast<uint8_t&>(map[p++]) == 0x98 ? 1 : 3; break;
+                case 1: lock = reinterpret_cast<uint8_t&>(map[p++]) == 0xA2 ? 0 : 3; break;
             }
         }
 


### PR DESCRIPTION
Compiling the NBS player on windows caused the following error:

`error C2440: 'reinterpret_cast': cannot convert from 'unsigned char' to 'uint8_t'`