### PR TITLE
Relative chart times to prevent floating point error

### DIFF
--- a/src/client/components/chart/line_chart/model.ts
+++ b/src/client/components/chart/line_chart/model.ts
@@ -33,11 +33,6 @@ export class LineChartModel {
   }
 
   @computed
-  get now() {
-    return this.model.now
-  }
-
-  @computed
   get bufferSeconds() {
     return this.model.bufferSeconds
   }

--- a/src/client/components/chart/line_chart/view_model.ts
+++ b/src/client/components/chart/line_chart/view_model.ts
@@ -1,6 +1,7 @@
 import * as bounds from 'binary-search-bounds'
 import { computed } from 'mobx'
 import { createTransformer } from 'mobx-utils'
+import { now } from 'mobx-utils'
 
 import { Transform } from '../../../math/transform'
 import { Vector2 } from '../../../math/vector2'
@@ -114,7 +115,7 @@ export class LineChartViewModel {
         })))
 
         lines.push(Shape.of(TextGeometry.of({
-          text: y.toString(),
+          text: y.toPrecision(2).toString(),
           worldScale: true,
           textAlign: 'end',
           fontSize: '1em',
@@ -149,7 +150,7 @@ export class LineChartViewModel {
   get xAxis(): Group {
 
     // Work out our min/max value
-    const max = this.model.now
+    const max = this.now
     const min = max - this.model.bufferSeconds
     const yRange = this.maxValue - this.minValue
 
@@ -210,7 +211,7 @@ export class LineChartViewModel {
     return Group.of({
       transform: Transform.of({
         translate: {
-          x: -(this.model.now - this.model.bufferSeconds / 2),
+          x: -(this.now - this.model.bufferSeconds / 2),
           y: -(minValue + (maxValue - minValue) / 2),
         },
       }),
@@ -229,7 +230,7 @@ export class LineChartViewModel {
       const max = this.dataSeries.reduce((maxValue, series: DataSeries) => {
 
         // Get the range we are viewing
-        let end = this.model.now + series.timeDelta
+        let end = this.now + series.timeDelta
         let start = end - this.model.bufferSeconds
 
         const values = series.series
@@ -254,7 +255,7 @@ export class LineChartViewModel {
       const min = this.dataSeries.reduce((minValue, series: DataSeries) => {
 
         // Get the range we are viewing
-        let end = this.model.now + series.timeDelta
+        let end = this.now + series.timeDelta
         let start = end - this.model.bufferSeconds
 
         const values = series.series
@@ -269,10 +270,15 @@ export class LineChartViewModel {
     }
   }
 
+  @computed
+  get now() {
+    return (now('frame') / 1000) - this.model.startTime
+  }
+
   private makeLines(series: DataSeries): Group {
 
     // Get the range we are viewing
-    let end = this.model.now + series.timeDelta
+    let end = this.now + series.timeDelta
     let start = end - this.model.bufferSeconds
 
     let values = series.series

--- a/src/client/components/chart/model.ts
+++ b/src/client/components/chart/model.ts
@@ -1,6 +1,5 @@
 import { observable } from 'mobx'
 import { computed } from 'mobx'
-import { now } from 'mobx-utils'
 
 import { Vector2 } from '../../math/vector2'
 import { BrowserSystemClock } from '../../time/browser_clock'
@@ -17,15 +16,17 @@ export class DataSeries {
 
   @observable highlight: boolean = false
   @observable color: string
+  @observable startTime: number
   @observable timeDelta: number
   @observable timeVariance: number
   @observable checked: CheckedState
   @observable series: Vector2[]
 
-  constructor({ color, checked, series, timeDelta, timeVariance, kf }: {
+  constructor({ color, checked, series, startTime, timeDelta, timeVariance, kf }: {
     color: string
     checked: CheckedState
     series: Vector2[]
+    startTime: number
     timeDelta: number
     timeVariance: number
     kf: { processNoise: number, measurementNoise: number }
@@ -33,16 +34,18 @@ export class DataSeries {
     this.color = color
     this.checked = checked
     this.series = series
+    this.startTime = startTime
     this.timeDelta = timeDelta
     this.timeVariance = timeVariance
     this.kf = kf
   }
 
-  static of() {
+  static of(startTime: number = 0) {
     return new DataSeries({
       color: '#ffffff',
       checked: CheckedState.Unchecked,
       series: [],
+      startTime,
       timeDelta: 0,
       timeVariance: 1,
       kf: { processNoise: 1e-3, measurementNoise: 1e-1 },
@@ -101,10 +104,5 @@ export class ChartModel {
       nodes: Array.from(this.treeData.entries(), ([label, model]) => TreeViewModel.of({ label, model })),
       usePessimisticToggle: true,
     }
-  }
-
-  @computed
-  get now() {
-    return (now('frame') / 1000) - this.startTime
   }
 }


### PR DESCRIPTION
Currently, when there is a big difference between the timestamps on the datapoints and the clock, floating point errors make the resulting chart fail to display properly.
This PR corrects the times on each so they are all relative to the first point we see.
This makes all numbers involved smaller and corrects the error.