### PR TITLE
Change chart network lifetime to when in view

### DIFF
--- a/src/client/components/chart/view.tsx
+++ b/src/client/components/chart/view.tsx
@@ -30,9 +30,11 @@ export class ChartView extends Component<{
     nusightNetwork: NUsightNetwork
     LineChart: ComponentType<LineChartProps>
   }): ComponentType {
-    const network = ChartNetwork.of(nusightNetwork, model)
     const controller = ChartController.of({ model })
-    return () => <ChartView controller={controller} Menu={menu} model={model} network={network} LineChart={LineChart}/>
+    return () => {
+      const network = ChartNetwork.of(nusightNetwork, model)
+      return <ChartView controller={controller} Menu={menu} model={model} network={network} LineChart={LineChart}/>
+    }
   }
 
   componentWillUnmount(): void {


### PR DESCRIPTION
The chart view can take up a lot of CPU power when it's not used.
This stops it from using that while you're not even looking at it.