### PR TITLE
Replace deprecated buffer constructors

### DIFF
--- a/src/client/nuclearnet/tests/web_socket_proxy_nuclearnet_client.tests.ts
+++ b/src/client/nuclearnet/tests/web_socket_proxy_nuclearnet_client.tests.ts
@@ -85,7 +85,7 @@ describe('WebSocketProxyNUClearNetClient', () => {
     it('forwards send calls to socket', () => {
       const opts = {
         type: 'foo',
-        payload: new Buffer(8),
+        payload: Buffer.alloc(8),
       }
       client.send(opts)
       expect(mockWebSocket.send).toHaveBeenCalledWith('foo', opts)

--- a/src/server/nbs/nbs_frame_chunker.ts
+++ b/src/server/nbs/nbs_frame_chunker.ts
@@ -20,7 +20,7 @@ export class NbsFrameChunker extends stream.Transform {
 
     this.foundHeader = false
     this.foundPacketSize = false
-    this.buffer = new Buffer(0)
+    this.buffer = Buffer.alloc(0)
   }
 
   static of(): NbsFrameChunker {
@@ -41,7 +41,7 @@ export class NbsFrameChunker extends stream.Transform {
     // If there are no headers within the data, just empty the buffer.
     // Prevents this being an unbounded buffer continually accumulating when no nbs packets are to be found.
     if (this.buffer.indexOf(NBS_HEADER) === -1) {
-      this.buffer = new Buffer(0)
+      this.buffer = Buffer.alloc(0)
     }
 
     done()

--- a/src/server/nbs/nbs_frame_codecs.ts
+++ b/src/server/nbs/nbs_frame_codecs.ts
@@ -29,11 +29,11 @@ export function encodeFrame(frame: NbsFrame): Buffer {
     `Expected hash buffer size of ${HASH_SIZE} but received ${frame.hash.byteLength}`)
 
   const size = TIMESTAMP_SIZE + HASH_SIZE + frame.payload.byteLength
-  const sizeBuffer = new Buffer(PACKET_SIZE_SIZE)
+  const sizeBuffer = Buffer.alloc(PACKET_SIZE_SIZE)
   sizeBuffer.writeUInt32LE(size, 0)
 
   const timeLong = Long.fromNumber(frame.timestampInMicroseconds)
-  const timestampBuffer = new Buffer(TIMESTAMP_SIZE)
+  const timestampBuffer = Buffer.alloc(TIMESTAMP_SIZE)
   timestampBuffer.writeUInt32LE(timeLong.getLowBitsUnsigned(), 0)
   timestampBuffer.writeUInt32LE(timeLong.getHighBitsUnsigned(), 4)
 

--- a/src/server/nbs/tests/nbs_frame_chunker.tests.ts
+++ b/src/server/nbs/tests/nbs_frame_chunker.tests.ts
@@ -17,7 +17,7 @@ describe('NbsFrameChunker', () => {
   }
 
   function randomBuffer(size: number) {
-    const buffer = new Buffer(size)
+    const buffer = Buffer.alloc(size)
     for (let i = 0; i < size; i++) {
       buffer[i] = randomByte()
     }
@@ -64,7 +64,7 @@ describe('NbsFrameChunker', () => {
       done()
     })
 
-    chunker.write(new Buffer(32).fill(randomByte()))
+    chunker.write(Buffer.alloc(32).fill(randomByte()))
     chunker.write(buffer1)
     chunker.write(buffer2)
     chunker.write(buffer3)
@@ -85,13 +85,13 @@ describe('NbsFrameChunker', () => {
     })
 
     // These random buffers are filled with a single random byte so as to not have a header
-    chunker.write(new Buffer(32).fill(randomByte()))
+    chunker.write(Buffer.alloc(32).fill(randomByte()))
     chunker.write(buffer1)
-    chunker.write(new Buffer(32).fill(randomByte()))
+    chunker.write(Buffer.alloc(32).fill(randomByte()))
     chunker.write(buffer2)
-    chunker.write(new Buffer(32).fill(randomByte()))
+    chunker.write(Buffer.alloc(32).fill(randomByte()))
     chunker.write(buffer3)
-    chunker.write(new Buffer(32).fill(randomByte()))
+    chunker.write(Buffer.alloc(32).fill(randomByte()))
     chunker.end()
   })
 

--- a/src/server/nbs/tests/nbs_frame_codecs.tests.ts
+++ b/src/server/nbs/tests/nbs_frame_codecs.tests.ts
@@ -10,7 +10,7 @@ describe('NbsFrameCodecs', () => {
     it('encodes frames', () => {
       const hash = hashType('message.input.sensors')
       const timestamp = 1500379664696000
-      const payload = new Buffer(8).fill(0x12)
+      const payload = Buffer.alloc(8).fill(0x12)
       const buffer = encodeFrame({ timestampInMicroseconds: timestamp, hash, payload })
       expect(buffer.toString('hex')).toEqual('e298a218000000c042f15c9654050010abef8b5398f0d41212121212121212')
     })
@@ -18,15 +18,15 @@ describe('NbsFrameCodecs', () => {
     it('encodes timestamps as unsigned integers', () => {
       const hash = hashType('message.input.sensors')
       const timestamp = -1 >>> 0 // Take any negative value and convert it to an unsigned integer.
-      const payload = new Buffer(8).fill(0x12)
+      const payload = Buffer.alloc(8).fill(0x12)
       const buffer = encodeFrame({ timestampInMicroseconds: timestamp, hash, payload })
       expect(buffer.toString('hex')).toEqual('e298a218000000ffffffff0000000010abef8b5398f0d41212121212121212')
     })
 
     it('errors if you supply an invalid hash size', () => {
-      const hash = new Buffer(12)
+      const hash = Buffer.alloc(12)
       const timestamp = 1500379664696000
-      const payload = new Buffer(8).fill(0x12)
+      const payload = Buffer.alloc(8).fill(0x12)
       const actual = () => encodeFrame({ timestampInMicroseconds: timestamp, hash, payload })
       expect(actual).toThrowError(/Expected hash buffer size/)
     })
@@ -35,7 +35,7 @@ describe('NbsFrameCodecs', () => {
       const packet: NUClearNetPacket = {
         peer: { name: 'Bob', address: '127.0.0.1', port: 1234 },
         hash: hashType('message.input.sensors'),
-        payload: new Buffer(8).fill(0x12),
+        payload: Buffer.alloc(8).fill(0x12),
         reliable: false,
       }
 
@@ -54,7 +54,7 @@ describe('NbsFrameCodecs', () => {
       expect(frame).toEqual({
         timestampInMicroseconds: 1500379664696000,
         hash: hashType('message.input.sensors'),
-        payload: new Buffer(8).fill(0x12),
+        payload: Buffer.alloc(8).fill(0x12),
       })
     })
   })
@@ -69,7 +69,7 @@ describe('NbsFrameCodecs', () => {
       const frame = {
         hash: hashType('message.input.sensors'),
         timestampInMicroseconds: 1500379664696000,
-        payload: new Buffer(8).fill(0x12),
+        payload: Buffer.alloc(8).fill(0x12),
       }
       expect(decodeFrame(encodeFrame(frame))).toEqual(frame)
     })

--- a/src/server/nbs/tests/nbs_frame_streams.tests.ts
+++ b/src/server/nbs/tests/nbs_frame_streams.tests.ts
@@ -9,7 +9,7 @@ describe('NbsFrameEncoder', () => {
     const frame = {
       timestampInMicroseconds: 0,
       hash: hashType('fake'),
-      payload: new Buffer(8).fill(12),
+      payload: Buffer.alloc(8).fill(12),
     }
     const buffer = encodeFrame(frame)
     const spy = jest.fn()
@@ -29,7 +29,7 @@ describe('NbsFrameDecoder', () => {
     const frame = {
       timestampInMicroseconds: 0,
       hash: hashType('fake'),
-      payload: new Buffer(8).fill(12),
+      payload: Buffer.alloc(8).fill(12),
     }
     const buffer = encodeFrame(frame)
     const spy = jest.fn()

--- a/src/server/nbs/tests/nbs_nuclear_playback.tests.ts
+++ b/src/server/nbs/tests/nbs_nuclear_playback.tests.ts
@@ -15,19 +15,19 @@ describe('NbsNUClearPlayback', () => {
     const frame1: NbsFrame = {
       timestampInMicroseconds: 0,
       hash: hashType('frame1'),
-      payload: new Buffer(8),
+      payload: Buffer.alloc(8),
     }
 
     const frame2: NbsFrame = {
       timestampInMicroseconds: 10e6, // 10 seconds
       hash: hashType('frame2'),
-      payload: new Buffer(8),
+      payload: Buffer.alloc(8),
     }
 
     const frame3: NbsFrame = {
       timestampInMicroseconds: 20e6, // 20 seconds
       hash: hashType('frame3'),
-      payload: new Buffer(8),
+      payload: Buffer.alloc(8),
     }
 
     jest.spyOn(nuclearnetClient, 'send')

--- a/src/server/nuclearnet/tests/fake_nuclearnet_client.tests.ts
+++ b/src/server/nuclearnet/tests/fake_nuclearnet_client.tests.ts
@@ -132,7 +132,7 @@ describe('FakeNUClearNetClient', () => {
     const onSensors = jest.fn()
     bob.on('sensors', onSensors)
 
-    const payload = new Buffer(8)
+    const payload = Buffer.alloc(8)
     bob.send({ type: 'sensors', payload })
 
     expect(onSensors).toHaveBeenCalledTimes(1)
@@ -156,7 +156,7 @@ describe('FakeNUClearNetClient', () => {
     const eveOnSensors = jest.fn()
     eve.on('sensors', eveOnSensors)
 
-    const payload = new Buffer(8)
+    const payload = Buffer.alloc(8)
     eve.send({ type: 'sensors', payload })
 
     expect(bobOnSensors).toHaveBeenCalledTimes(1)
@@ -192,7 +192,7 @@ describe('FakeNUClearNetClient', () => {
     const eveOnSensors = jest.fn()
     eve.on('sensors', eveOnSensors)
 
-    const payload = new Buffer(8)
+    const payload = Buffer.alloc(8)
     eve.send({ type: 'sensors', payload })
 
     expect(bobOnPacket).toHaveBeenCalledTimes(1)
@@ -228,7 +228,7 @@ describe('FakeNUClearNetClient', () => {
     const eveOnSensors = jest.fn()
     eve.on('sensors', eveOnSensors)
 
-    const payload = new Buffer(8)
+    const payload = Buffer.alloc(8)
     eve.send({ type: 'sensors', payload, target: 'bob' })
 
     expect(bobOnSensors).toHaveBeenCalledTimes(1)
@@ -258,7 +258,7 @@ describe('FakeNUClearNetClient', () => {
     const eveOnSensors = jest.fn()
     eve.on('sensors', eveOnSensors)
 
-    const payload = new Buffer(8)
+    const payload = Buffer.alloc(8)
     eve.send({ type: 'sensors', payload, target: 'bob' })
 
     expect(bobOnSensors1).toHaveBeenCalledTimes(1)

--- a/src/shared/nuclearnet/tests/nuclearnet_proxy_parser.tests.ts
+++ b/src/shared/nuclearnet/tests/nuclearnet_proxy_parser.tests.ts
@@ -139,8 +139,8 @@ describe('NUClearNetProxyParser', () => {
           address: '192.168.2.11',
           port: randomPort(),
         },
-        hash: new Buffer(8),
-        payload: new Buffer(1000),
+        hash: Buffer.alloc(8),
+        payload: Buffer.alloc(1000),
         reliable: true,
       },
       {
@@ -149,8 +149,8 @@ describe('NUClearNetProxyParser', () => {
           address: '192.168.2.11',
           port: randomPort(),
         },
-        hash: new Buffer(8),
-        payload: new Buffer(1000),
+        hash: Buffer.alloc(8),
+        payload: Buffer.alloc(1000),
         reliable: true,
       },
     ]

--- a/src/virtual_robots/virtual_robot.ts
+++ b/src/virtual_robots/virtual_robot.ts
@@ -52,7 +52,7 @@ export class VirtualRobot {
   send(messageType: string, buffer: Uint8Array, reliable?: boolean) {
     this.network.send({
       type: messageType,
-      payload: new Buffer(buffer),
+      payload: Buffer.from(buffer),
       target: 'nusight',
       reliable,
     })


### PR DESCRIPTION
```
DeprecationWarning: Buffer() is deprecated due to security and usability issues.
Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```