### PR TITLE
Add priority queue to improve network performance

### DIFF
--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -72,7 +72,7 @@ function init() {
         { frequency: 1, simulator: OverviewSimulator.of() },
         { frequency: 60, simulator: SensorDataSimulator.of() },
         { frequency: 60, simulator: ChartSimulator.of() },
-        { frequency: 1, simulator: VisionSimulator.of() },
+        { frequency: 2, simulator: VisionSimulator.of() },
       ],
     })
     virtualRobots.startSimulators()

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -72,7 +72,7 @@ function init() {
         { frequency: 1, simulator: OverviewSimulator.of() },
         { frequency: 60, simulator: SensorDataSimulator.of() },
         { frequency: 60, simulator: ChartSimulator.of() },
-        { frequency: 2, simulator: VisionSimulator.of() },
+        { frequency: 5, simulator: VisionSimulator.of() },
       ],
     })
     virtualRobots.startSimulators()

--- a/src/server/nuclearnet/lru_priority_queue.ts
+++ b/src/server/nuclearnet/lru_priority_queue.ts
@@ -1,0 +1,40 @@
+type Item<K, V> = {
+  type: K,
+  values: V[]
+}
+
+export class LruPriorityQueue<K, V> {
+  private readonly limitPerKey?: number
+
+  queue: Array<Item<K, V>> = []
+  map: Map<K, Item<K, V>> = new Map()
+
+  constructor({ limitPerKey }: { limitPerKey?: number } = {}) {
+    this.limitPerKey = limitPerKey
+  }
+
+  add(k: K, v: V) {
+    let item = this.map.get(k)
+    if (!item) {
+      item = { type: k, values: [] }
+      this.map.set(k, item)
+      this.queue.push(item)
+    }
+    if (this.limitPerKey && item.values.length >= this.limitPerKey) {
+      item.values.shift()
+    }
+    item.values.push(v)
+  }
+
+  next(): { key: K, value: V } | undefined {
+    /* tslint:disable-next-line prefer-for-of */
+    for (let i = 0; i < this.queue.length; i++) {
+      const item = this.queue.shift()!
+      this.queue.push(item)
+      const nextValue = item.values.shift()
+      if (nextValue) {
+        return { key: item.type, value: nextValue }
+      }
+    }
+  }
+}

--- a/src/server/nuclearnet/lru_priority_queue.ts
+++ b/src/server/nuclearnet/lru_priority_queue.ts
@@ -6,6 +6,7 @@ type Item<K, V> = { key: K, values: V[] }
  * Optionally can limit the queue capacity per key, favouring the newest entries and dropping the oldest ones.
  */
 export class LruPriorityQueue<K, V> {
+  private size: number = 0
   private readonly capacityPerKey?: number
   private readonly queue: Array<Item<K, V>> = []
   private readonly map: Map<K, Item<K, V>> = new Map()
@@ -23,17 +24,23 @@ export class LruPriorityQueue<K, V> {
     }
     if (this.capacityPerKey && item.values.length >= this.capacityPerKey) {
       item.values.shift()
+      this.size--
     }
     item.values.push(value)
+    this.size++
   }
 
   pop(): V | undefined {
+    if (!this.size) {
+      return
+    }
     /* tslint:disable-next-line prefer-for-of */
     for (let i = 0; i < this.queue.length; i++) {
       const item = this.queue.shift()!
       this.queue.push(item)
       const value = item.values.shift()
       if (value) {
+        this.size--
         return value
       }
     }

--- a/src/server/nuclearnet/lru_priority_queue.ts
+++ b/src/server/nuclearnet/lru_priority_queue.ts
@@ -1,5 +1,5 @@
 type Item<K, V> = {
-  type: K,
+  key: K,
   values: V[]
 }
 
@@ -12,17 +12,17 @@ export class LruPriorityQueue<K, V> {
     this.limitPerKey = limitPerKey
   }
 
-  add(k: K, v: V) {
-    let item = this.map.get(k)
+  add(key: K, value: V) {
+    let item = this.map.get(key)
     if (!item) {
-      item = { type: k, values: [] }
-      this.map.set(k, item)
+      item = { key, values: [] }
+      this.map.set(key, item)
       this.queue.push(item)
     }
     if (this.limitPerKey && item.values.length >= this.limitPerKey) {
       item.values.shift()
     }
-    item.values.push(v)
+    item.values.push(value)
   }
 
   next(): { key: K, value: V } | undefined {
@@ -32,7 +32,7 @@ export class LruPriorityQueue<K, V> {
       this.queue.push(item)
       const nextValue = item.values.shift()
       if (nextValue) {
-        return { key: item.type, value: nextValue }
+        return { key: item.key, value: nextValue }
       }
     }
   }

--- a/src/server/nuclearnet/lru_priority_queue.ts
+++ b/src/server/nuclearnet/lru_priority_queue.ts
@@ -1,20 +1,17 @@
-type Item<K, V> = {
-  key: K,
-  values: V[]
-}
+type Item<K, V> = { key: K, values: V[] }
 
 /**
  * A priority queue which favours values whose keys are the least recently used (LRU).
  *
- * Optionally can limit the queue length per key, favouring the newest entries and dropping old ones.
+ * Optionally can limit the queue capacity per key, favouring the newest entries and dropping the oldest ones.
  */
 export class LruPriorityQueue<K, V> {
-  private readonly limitPerKey?: number
+  private readonly capacityPerKey?: number
   private readonly queue: Array<Item<K, V>> = []
   private readonly map: Map<K, Item<K, V>> = new Map()
 
-  constructor({ limitPerKey }: { limitPerKey?: number } = {}) {
-    this.limitPerKey = limitPerKey
+  constructor({ capacityPerKey }: { capacityPerKey?: number } = {}) {
+    this.capacityPerKey = capacityPerKey
   }
 
   add(key: K, value: V) {
@@ -24,7 +21,7 @@ export class LruPriorityQueue<K, V> {
       this.map.set(key, item)
       this.queue.push(item)
     }
-    if (this.limitPerKey && item.values.length >= this.limitPerKey) {
+    if (this.capacityPerKey && item.values.length >= this.capacityPerKey) {
       item.values.shift()
     }
     item.values.push(value)

--- a/src/server/nuclearnet/lru_priority_queue.ts
+++ b/src/server/nuclearnet/lru_priority_queue.ts
@@ -5,9 +5,8 @@ type Item<K, V> = {
 
 export class LruPriorityQueue<K, V> {
   private readonly limitPerKey?: number
-
-  queue: Array<Item<K, V>> = []
-  map: Map<K, Item<K, V>> = new Map()
+  private readonly queue: Array<Item<K, V>> = []
+  private readonly map: Map<K, Item<K, V>> = new Map()
 
   constructor({ limitPerKey }: { limitPerKey?: number } = {}) {
     this.limitPerKey = limitPerKey

--- a/src/server/nuclearnet/lru_priority_queue.ts
+++ b/src/server/nuclearnet/lru_priority_queue.ts
@@ -25,14 +25,14 @@ export class LruPriorityQueue<K, V> {
     item.values.push(value)
   }
 
-  next(): { key: K, value: V } | undefined {
+  pop(): V | undefined {
     /* tslint:disable-next-line prefer-for-of */
     for (let i = 0; i < this.queue.length; i++) {
       const item = this.queue.shift()!
       this.queue.push(item)
-      const nextValue = item.values.shift()
-      if (nextValue) {
-        return { key: item.key, value: nextValue }
+      const value = item.values.shift()
+      if (value) {
+        return value
       }
     }
   }

--- a/src/server/nuclearnet/lru_priority_queue.ts
+++ b/src/server/nuclearnet/lru_priority_queue.ts
@@ -3,6 +3,11 @@ type Item<K, V> = {
   values: V[]
 }
 
+/**
+ * A priority queue which favours values whose keys are the least recently used (LRU).
+ *
+ * Optionally can limit the queue length per key, favouring the newest entries and dropping old ones.
+ */
 export class LruPriorityQueue<K, V> {
   private readonly limitPerKey?: number
   private readonly queue: Array<Item<K, V>> = []

--- a/src/server/nuclearnet/tests/lru_priority_queue.tests.ts
+++ b/src/server/nuclearnet/tests/lru_priority_queue.tests.ts
@@ -1,8 +1,14 @@
 import { LruPriorityQueue } from '../lru_priority_queue'
 
 describe('LruPriorityQueue', () => {
-  /** Fetch all remaining items in the queue, in priority order.  */
-  function all<K, V>(queue: LruPriorityQueue<K, V>): V[] {
+  let queue: LruPriorityQueue<string, string>
+
+  beforeEach(() => {
+    queue = new LruPriorityQueue<string, string>()
+  })
+
+  /** Pop and return all items in the queue, in priority order. */
+  function popAll<K, V>(queue: LruPriorityQueue<K, V>): V[] {
     const items: V[] = []
     let item: V | undefined
     /* tslint:disable-next-line no-conditional-assignment */
@@ -12,19 +18,31 @@ describe('LruPriorityQueue', () => {
     return items
   }
 
-  it('interleaves keys', () => {
-    const queue = new LruPriorityQueue<string, string>()
+  it('returns undefined when no keys have been added', () => {
+    expect(queue.pop()).toBe(undefined)
+  })
+
+  it('returns values currently in queue and then undefined', () => {
+    queue.add('foo', 'foo_1')
+    expect(queue.pop()).toBe('foo_1')
+    expect(queue.pop()).toBe(undefined)
+    queue.add('bar', 'bar_1')
+    expect(queue.pop()).toBe('bar_1')
+    expect(queue.pop()).toBe(undefined)
+  })
+
+  it('orders values by least recently used key', () => {
     queue.add('foo', 'foo_1')
     queue.add('foo', 'foo_2')
     queue.add('bar', 'bar_1')
     queue.add('bar', 'bar_2')
     queue.add('baz', 'baz_1')
     queue.add('baz', 'baz_2')
-    expect(all(queue)).toEqual(['foo_1', 'bar_1', 'baz_1', 'foo_2', 'bar_2', 'baz_2'])
+    expect(popAll(queue)).toEqual(['foo_1', 'bar_1', 'baz_1', 'foo_2', 'bar_2', 'baz_2'])
   })
 
-  it('drops items when over limit', () => {
-    const queue = new LruPriorityQueue<string, string>({ limitPerKey: 2 })
+  it('drops older values when keys are over capacity', () => {
+    const queue = new LruPriorityQueue<string, string>({ capacityPerKey: 2 })
     queue.add('foo', 'foo_1')
     queue.add('foo', 'foo_2')
     queue.add('foo', 'foo_3')
@@ -32,6 +50,6 @@ describe('LruPriorityQueue', () => {
     queue.add('bar', 'bar_1')
     queue.add('bar', 'bar_2')
     queue.add('bar', 'bar_3')
-    expect(all(queue)).toEqual(['foo_3', 'bar_2', 'foo_4', 'bar_3'])
+    expect(popAll(queue)).toEqual(['foo_3', 'bar_2', 'foo_4', 'bar_3'])
   })
 })

--- a/src/server/nuclearnet/tests/lru_priority_queue.tests.ts
+++ b/src/server/nuclearnet/tests/lru_priority_queue.tests.ts
@@ -20,14 +20,7 @@ describe('LruPriorityQueue', () => {
     queue.add('bar', 'bar_2')
     queue.add('baz', 'baz_1')
     queue.add('baz', 'baz_2')
-    expect(all(queue)).toEqual([
-      { key: 'foo', value: 'foo_1' },
-      { key: 'bar', value: 'bar_1' },
-      { key: 'baz', value: 'baz_1' },
-      { key: 'foo', value: 'foo_2' },
-      { key: 'bar', value: 'bar_2' },
-      { key: 'baz', value: 'baz_2' },
-    ])
+    expect(all(queue)).toEqual(['foo_1', 'bar_1', 'baz_1', 'foo_2', 'bar_2', 'baz_2'])
   })
 
   it('drops items when over limit', () => {
@@ -39,11 +32,6 @@ describe('LruPriorityQueue', () => {
     queue.add('bar', 'bar_1')
     queue.add('bar', 'bar_2')
     queue.add('bar', 'bar_3')
-    expect(all(queue)).toEqual([
-      { key: 'foo', value: 'foo_3' },
-      { key: 'bar', value: 'bar_2' },
-      { key: 'foo', value: 'foo_4' },
-      { key: 'bar', value: 'bar_3' },
-    ])
+    expect(all(queue)).toEqual(['foo_3', 'bar_2', 'foo_4', 'bar_3'])
   })
 })

--- a/src/server/nuclearnet/tests/lru_priority_queue.tests.ts
+++ b/src/server/nuclearnet/tests/lru_priority_queue.tests.ts
@@ -1,0 +1,49 @@
+import { LruPriorityQueue } from '../lru_priority_queue'
+
+describe('LruPriorityQueue', () => {
+  /** Fetch all remaining items in the queue, in priority order.  */
+  function all<K, V>(queue: LruPriorityQueue<K, V>): Array<{ key: K, value: V }> {
+    const items: Array<{ key: K, value: V }> = []
+    let item: { key: K, value: V } | undefined
+    /* tslint:disable-next-line no-conditional-assignment */
+    while ((item = queue.next())) {
+      items.push(item)
+    }
+    return items
+  }
+
+  it('interleaves keys', () => {
+    const queue = new LruPriorityQueue<string, string>()
+    queue.add('foo', 'foo_1')
+    queue.add('foo', 'foo_2')
+    queue.add('bar', 'bar_1')
+    queue.add('bar', 'bar_2')
+    queue.add('baz', 'baz_1')
+    queue.add('baz', 'baz_2')
+    expect(all(queue)).toEqual([
+      { key: 'foo', value: 'foo_1' },
+      { key: 'bar', value: 'bar_1' },
+      { key: 'baz', value: 'baz_1' },
+      { key: 'foo', value: 'foo_2' },
+      { key: 'bar', value: 'bar_2' },
+      { key: 'baz', value: 'baz_2' },
+    ])
+  })
+
+  it('drops items when over limit', () => {
+    const queue = new LruPriorityQueue<string, string>({ limitPerKey: 2 })
+    queue.add('foo', 'foo_1')
+    queue.add('foo', 'foo_2')
+    queue.add('foo', 'foo_3')
+    queue.add('foo', 'foo_4')
+    queue.add('bar', 'bar_1')
+    queue.add('bar', 'bar_2')
+    queue.add('bar', 'bar_3')
+    expect(all(queue)).toEqual([
+      { key: 'foo', value: 'foo_3' },
+      { key: 'bar', value: 'bar_2' },
+      { key: 'foo', value: 'foo_4' },
+      { key: 'bar', value: 'bar_3' },
+    ])
+  })
+})

--- a/src/server/nuclearnet/tests/lru_priority_queue.tests.ts
+++ b/src/server/nuclearnet/tests/lru_priority_queue.tests.ts
@@ -2,11 +2,11 @@ import { LruPriorityQueue } from '../lru_priority_queue'
 
 describe('LruPriorityQueue', () => {
   /** Fetch all remaining items in the queue, in priority order.  */
-  function all<K, V>(queue: LruPriorityQueue<K, V>): Array<{ key: K, value: V }> {
-    const items: Array<{ key: K, value: V }> = []
-    let item: { key: K, value: V } | undefined
+  function all<K, V>(queue: LruPriorityQueue<K, V>): V[] {
+    const items: V[] = []
+    let item: V | undefined
     /* tslint:disable-next-line no-conditional-assignment */
-    while ((item = queue.next())) {
+    while ((item = queue.pop())) {
       items.push(item)
     }
     return items

--- a/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
+++ b/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
@@ -8,6 +8,7 @@ import { NodeSystemClock } from '../time/node_clock'
 
 import { DirectNUClearNetClient } from './direct_nuclearnet_client'
 import { FakeNUClearNetClient } from './fake_nuclearnet_client'
+import { LruPriorityQueue } from './lru_priority_queue'
 import { WebSocketServer } from './web_socket_server'
 import { WebSocket } from './web_socket_server'
 
@@ -40,14 +41,16 @@ class WebSocketServerClient {
   private offJoin: () => void
   private offLeave: () => void
   private offListenMap: Map<string, () => void>
-  private processors: Map<NUClearNetPeer, PacketProcessor>
 
-  constructor(private nuclearnetClient: NUClearNetClient, private socket: WebSocket) {
+  constructor(
+    private nuclearnetClient: NUClearNetClient,
+    private socket: WebSocket,
+    private processor: PacketProcessor,
+  ) {
     this.connected = false
     this.offJoin = this.nuclearnetClient.onJoin(this.onJoin)
     this.offLeave = this.nuclearnetClient.onLeave(this.onLeave)
     this.offListenMap = new Map()
-    this.processors = new Map()
 
     this.socket.on('listen', this.onListen)
     this.socket.on('unlisten', this.onUnlisten)
@@ -56,20 +59,15 @@ class WebSocketServerClient {
   }
 
   static of(nuclearNetClient: NUClearNetClient, socket: WebSocket) {
-    return new WebSocketServerClient(nuclearNetClient, socket)
+    return new WebSocketServerClient(nuclearNetClient, socket, PacketProcessor.of(socket))
   }
 
   private onJoin = (peer: NUClearNetPeer) => {
     this.socket.send('nuclear_join', peer)
-    this.processors.set(peer, PacketProcessor.of(this.socket))
   }
 
   private onLeave = (peer: NUClearNetPeer) => {
     this.socket.send('nuclear_leave', peer)
-    const peerKey = this.getPeer(this.processors.keys(), peer)
-    if (peerKey) {
-      this.processors.delete(peerKey)
-    }
   }
 
   private onConnect = (options: NUClearNetOptions) => {
@@ -104,58 +102,43 @@ class WebSocketServerClient {
   }
 
   private onPacket = (event: string, packet: NUClearNetPacket) => {
-    const peerKey = this.getPeer(this.processors.keys(), packet.peer)
-    if (peerKey) {
-      const processor = this.processors.get(peerKey)
-      if (processor) {
-        processor.onPacket(event, packet)
-      }
-    }
-  }
-
-  /**
-   * Look for the needle 'peer' inside the haystack 'peers'. They might not be the same object reference.
-   */
-  private getPeer(peers: Iterable<NUClearNetPeer>, peer: NUClearNetPeer): NUClearNetPeer | undefined {
-    return Array.from(peers).find(otherPeer => {
-      return otherPeer.name === peer.name && otherPeer.address === peer.address && otherPeer.port === peer.port
-    })
+    this.processor.onPacket(event, packet)
   }
 }
 
 class PacketProcessor {
-  private eventQueueSize: Map<string, number>
+  private outgoingPackets: number = 0
 
-  // The maximum number of packets of a unique type to send before receiving acknowledgements.
-  private limit: number
+  // The maximum number of packets to send before receiving acknowledgements.
+  private outgoingLimit: number
 
   // The number of seconds before giving up on an acknowledge
   private timeout: number
 
   constructor(private socket: WebSocket,
               private clock: Clock,
-              opts: { limit: number, timeout: number }) {
-    this.limit = opts.limit
-    this.timeout = opts.timeout
-    this.eventQueueSize = new Map()
+              private queue: LruPriorityQueue<string, { event: string, packet: NUClearNetPacket }>,
+              { outgoingLimit, timeout }: { outgoingLimit: number, timeout: number }) {
+    this.outgoingLimit = outgoingLimit
+    this.timeout = timeout
+    this.queue = queue
   }
 
   static of(socket: WebSocket) {
-    return new PacketProcessor(socket, NodeSystemClock, { limit: 2, timeout: 1 })
+    return new PacketProcessor(
+      socket,
+      NodeSystemClock,
+      new LruPriorityQueue({ limitPerKey: 2 }),
+      { outgoingLimit: 10, timeout: 5 },
+    )
   }
 
   onPacket(event: string, packet: NUClearNetPacket) {
     if (packet.reliable) {
       this.sendReliablePacket(event, packet)
-    } else if (this.isEventBelowLimit(event)) {
+    } else {
       this.sendUnreliablePacket(event, packet)
-    }/* else {
-      // This event is unreliable and already at the limit, simply drop the packet.
-    }*/
-  }
-
-  private isEventBelowLimit(event: string) {
-    return (this.eventQueueSize.get(event) || 0) < this.limit
+    }
   }
 
   private sendReliablePacket(event: string, packet: NUClearNetPacket) {
@@ -165,21 +148,27 @@ class PacketProcessor {
 
   private sendUnreliablePacket(event: string, packet: NUClearNetPacket) {
     // Throttle unreliable packets so that we do not overwhelm the client with traffic.
-    const done = this.enqueue(event)
-    this.socket.volatileSend(event, packet, done)
-    this.clock.setTimeout(done, this.timeout)
+    const key = `${event}:${packet.peer.name}:${packet.peer.address}:${packet.peer.port}`
+    this.queue.add(key, { event, packet })
+    this.maybeSendNextPacket()
   }
 
-  private enqueue(event: string): () => void {
-    let isDone = false
-    const eventQueueSize = this.eventQueueSize.get(event) || 0
-    this.eventQueueSize.set(event, eventQueueSize + 1)
-
-    return () => {
-      if (!isDone) {
-        const eventQueueSize = this.eventQueueSize.get(event) || 0
-        this.eventQueueSize.set(event, eventQueueSize - 1)
-        isDone = true
+  private maybeSendNextPacket() {
+    if (this.outgoingPackets < this.outgoingLimit) {
+      const next = this.queue.next()
+      if (next) {
+        const { value: { event, packet } } = next
+        let isDone = false
+        const done = () => {
+          if (!isDone) {
+            this.outgoingPackets--
+            isDone = true
+            this.maybeSendNextPacket()
+          }
+        }
+        this.outgoingPackets++
+        this.socket.volatileSend(event, packet, done)
+        this.clock.setTimeout(done, this.timeout)
       }
     }
   }

--- a/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
+++ b/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
@@ -155,9 +155,9 @@ class PacketProcessor {
 
   private maybeSendNextPacket() {
     if (this.outgoingPackets < this.outgoingLimit) {
-      const next = this.queue.next()
+      const next = this.queue.pop()
       if (next) {
-        const { value: { event, packet } } = next
+        const { event, packet } = next
         let isDone = false
         const done = () => {
           if (!isDone) {

--- a/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
+++ b/src/server/nuclearnet/web_socket_proxy_nuclearnet_server.ts
@@ -128,7 +128,7 @@ class PacketProcessor {
     return new PacketProcessor(
       socket,
       NodeSystemClock,
-      new LruPriorityQueue({ limitPerKey: 2 }),
+      new LruPriorityQueue({ capacityPerKey: 2 }),
       { outgoingLimit: 10, timeout: 5 },
     )
   }

--- a/src/server/prod.ts
+++ b/src/server/prod.ts
@@ -48,7 +48,7 @@ if (withVirtualRobots) {
       { frequency: 1, simulator: OverviewSimulator.of() },
       { frequency: 10, simulator: SensorDataSimulator.of() },
       { frequency: 10, simulator: ChartSimulator.of() },
-      { frequency: 1, simulator: VisionSimulator.of() },
+      { frequency: 5, simulator: VisionSimulator.of() },
     ],
   })
   virtualRobots.startSimulators()


### PR DESCRIPTION
The general idea here is to keep client-side data as fresh as possible by biasing the packets we send towards the types we haven't sent recently.

i.e. we favour sending messages for event types that we have least recently sent.

The key used is `${event}:${packet.peer.name}:${packet.peer.address}:${packet.peer.port}`, which basically means we round-robin packets per-robot and per-event type, replacing anything old with newer packets as we go around.

Works pretty well!