### PR TITLE
Add disposableComputed helper

### DIFF
--- a/src/client/base/disposable_computed.ts
+++ b/src/client/base/disposable_computed.ts
@@ -1,0 +1,19 @@
+import { IComputedValue } from 'mobx'
+import { onBecomeUnobserved } from 'mobx'
+import { computed } from 'mobx'
+
+/**
+ * Designed for creating computed values for managed resources which need to be disposed of after use.
+ *
+ * Any stale values will be disposed, and the last value will be disposed when the computed is no longer observed.
+ */
+export const disposableComputed = <T extends { dispose(): void; }>(fn: () => T): IComputedValue<T> => {
+  let latest: T | undefined
+  const expr = computed(() => {
+    latest && latest.dispose()
+    latest = fn()
+    return latest
+  })
+  onBecomeUnobserved(expr, () => latest && latest.dispose())
+  return expr
+}

--- a/src/client/base/tests/disposable_computed.tests.ts
+++ b/src/client/base/tests/disposable_computed.tests.ts
@@ -1,0 +1,71 @@
+import { IComputedValue } from 'mobx'
+import { observable } from 'mobx'
+import { autorun } from 'mobx'
+
+import { disposableComputed } from '../disposable_computed'
+
+describe('disposableComputed', () => {
+  let model: { a: number, b: number }
+  let expr: IComputedValue<{ sum: number, dispose: jest.Mock<() => void> }>
+
+  beforeEach(() => {
+    model = observable({ a: 1, b: 1 })
+    expr = disposableComputed(() => ({ sum: model.a + model.b, dispose: jest.fn<() => void>() }))
+  })
+
+  it('returns value on evaluation', () => {
+    const value = { foo: 'bar', dispose: jest.fn() }
+    const expr = disposableComputed(() => value)
+    expect(expr.get()).toBe(value)
+  })
+
+  describe('when unobserved', () => {
+    it('creates new values when repeatably evaluated', () => {
+      const someValues = Array.from({ length: 5 }, () => expr.get())
+      expect(new Set(someValues).size).toBe(5)
+    })
+
+    it('disposes stale values when repeatably evaluated', () => {
+      const someValues = Array.from({ length: 5 }, () => expr.get())
+      const allButLast = someValues.slice(0, -1)
+      allButLast.forEach(value => expect(value.dispose).toHaveBeenCalled())
+    })
+  })
+
+  describe('when observed', () => {
+    let dispose: () => void
+
+    beforeEach(() => {
+      dispose = autorun(() => expr.get())
+    })
+
+    it('caches value when repeatably evaluated', () => {
+      const someValues = Array.from({ length: 5 }, () => expr.get())
+      expect(new Set(someValues).size).toBe(1)
+      someValues.forEach(value => expect(value.dispose).not.toHaveBeenCalled())
+    })
+
+    it('does not dispose value', () => {
+      const value = expr.get()
+      expect(value.dispose).not.toHaveBeenCalled()
+    })
+
+    it('dispoes stale value after recomputation', () => {
+      const value = expr.get()
+      model.a++
+      expect(value.dispose).toHaveBeenCalled()
+    })
+
+    it('dispoes value after disposes observing reaction', () => {
+      const value = expr.get()
+      dispose()
+      expect(value.dispose).toHaveBeenCalled()
+    })
+
+    it('creates new values when repeatably evaluated after disposing observing reaction', () => {
+      dispose()
+      const someValues = Array.from({ length: 5 }, () => expr.get())
+      expect(new Set(someValues).size).toBe(5)
+    })
+  })
+})

--- a/src/client/components/three/stories/three.stories.tsx
+++ b/src/client/components/three/stories/three.stories.tsx
@@ -1,14 +1,14 @@
 import { storiesOf } from '@storybook/react'
-import { IComputedValue } from 'mobx'
 import { reaction } from 'mobx'
 import { observable } from 'mobx'
 import { action } from 'mobx'
 import { computed } from 'mobx'
+import { IComputedValue } from 'mobx'
 import { disposeOnUnmount } from 'mobx-react'
 import { now } from 'mobx-utils'
 import { Component } from 'react'
 import * as React from 'react'
-import { Light } from 'three'
+import { Scene } from 'three'
 import { Object3D } from 'three'
 import { Material } from 'three'
 import { Geometry } from 'three'
@@ -18,8 +18,9 @@ import { MeshPhongMaterial } from 'three'
 import { Mesh } from 'three'
 import { BoxGeometry } from 'three'
 import { PerspectiveCamera } from 'three'
-import { Scene } from 'three'
+import { Light } from 'three'
 
+import { disposableComputed } from '../../../base/disposable_computed'
 import { Vector2 } from '../../../math/vector2'
 import { Vector3 } from '../../../math/vector3'
 import { Stage } from '../three'
@@ -59,9 +60,9 @@ class BoxVisualiser extends Component<{ animate?: boolean }> {
   }
 
   private createStage = (canvas: Canvas): IComputedValue<Stage> => {
-    const geometry = computed(() => this.boxGeometry())
+    const geometry = disposableComputed(() => this.boxGeometry())
     const box = (box: BoxModel) => {
-      const material = computed(() => this.boxMaterial(box))
+      const material = disposableComputed(() => this.boxMaterial(box))
       return computed(() => this.box(box, geometry.get(), material.get()))
     }
     const camera = computed(() => this.camera(canvas))


### PR DESCRIPTION
To prevent memory leaks for computed values which need cleaning up after use, this PR introduces `disposableComputed` to solve that problem.

It acts the same as `computed`, in that it returns an observable expression which can later be evaluated to a value. The difference is that it will automatically call the dispose method on old values  when they become stale or the expression becomes unobserved.

See tests for details.