### PR TITLE
Add support for non-periodic simulators

### DIFF
--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -13,6 +13,7 @@ import webpackConfig from '../../webpack.config'
 import * as NUClearNetProxyParser from '../shared/nuclearnet/nuclearnet_proxy_parser'
 import { ChartSimulator } from '../virtual_robots/simulators/chart_data_simulator'
 import { OverviewSimulator } from '../virtual_robots/simulators/overview_simulator'
+import { ScriptDataSimulator } from '../virtual_robots/simulators/script_data_simulator'
 import { SensorDataSimulator } from '../virtual_robots/simulators/sensor_data_simulator'
 import { VisionSimulator } from '../virtual_robots/simulators/vision_simulator'
 import { VirtualRobots } from '../virtual_robots/virtual_robots'
@@ -68,12 +69,13 @@ function init() {
     const virtualRobots = VirtualRobots.of({
       fakeNetworking: true,
       numRobots: 3,
-      simulators: [
+      periodicSimulators: [
         { frequency: 1, simulator: OverviewSimulator.of() },
         { frequency: 60, simulator: SensorDataSimulator.of() },
         { frequency: 60, simulator: ChartSimulator.of() },
         { frequency: 5, simulator: VisionSimulator.of() },
       ],
+      simulators: [ScriptDataSimulator.of()],
     })
     virtualRobots.startSimulators()
   }

--- a/src/server/prod.ts
+++ b/src/server/prod.ts
@@ -44,12 +44,13 @@ if (withVirtualRobots) {
   const virtualRobots = VirtualRobots.of({
     fakeNetworking: true,
     numRobots: 3,
-    simulators: [
+    periodicSimulators: [
       { frequency: 1, simulator: OverviewSimulator.of() },
       { frequency: 10, simulator: SensorDataSimulator.of() },
       { frequency: 10, simulator: ChartSimulator.of() },
       { frequency: 5, simulator: VisionSimulator.of() },
     ],
+    simulators: [],
   })
   virtualRobots.startSimulators()
 }

--- a/src/tests/networking_integration.tests.ts
+++ b/src/tests/networking_integration.tests.ts
@@ -33,10 +33,11 @@ describe('Networking Integration', () => {
           NodeSystemClock,
           {
             name: 'Robot #1',
-            simulators: [
+            periodicSimulators: [
               { frequency: 1, simulator: OverviewSimulator.of() },
               { frequency: 60, simulator: SensorDataSimulator.of() },
             ],
+            simulators: [],
           },
         ),
       ],

--- a/src/virtual_robots/run.ts
+++ b/src/virtual_robots/run.ts
@@ -1,35 +1,49 @@
 import * as minimist from 'minimist'
 
+import { Simulator } from './simulator'
 import { OverviewSimulator } from './simulators/overview_simulator'
+import { ScriptDataSimulator } from './simulators/script_data_simulator'
 import { SensorDataSimulator } from './simulators/sensor_data_simulator'
-import { SimulatorOpts } from './virtual_robot'
+import { PeriodicSimulatorOpts } from './virtual_robot'
 import { VirtualRobots } from './virtual_robots'
 
 function main() {
   const args = minimist(process.argv.slice(2))
 
-  const simulators = getSimulators(args)
+  const { simulators, periodicSimulators } = getSimulators(args)
   const virtualRobots = VirtualRobots.of({
     fakeNetworking: false,
     numRobots: 6,
     simulators,
+    periodicSimulators,
   })
   virtualRobots.startSimulators()
 }
 
-function getSimulators(args: minimist.ParsedArgs): SimulatorOpts[] {
+function getSimulators(args: minimist.ParsedArgs): {
+  simulators: Simulator[],
+  periodicSimulators: PeriodicSimulatorOpts[]
+} {
   const simulators = []
+  const periodicSimulators = []
+
   if (args.overview || args.all) {
-    simulators.push({ frequency: 1, simulator: OverviewSimulator.of() })
+    periodicSimulators.push({ frequency: 1, simulator: OverviewSimulator.of() })
   }
   if (args.sensors || args.all) {
-    simulators.push({ frequency: 60, simulator: SensorDataSimulator.of() })
+    periodicSimulators.push({ frequency: 60, simulator: SensorDataSimulator.of() })
   }
-  if (simulators.length === 0) {
+  if (args.scripts || args.all) {
+    simulators.push(ScriptDataSimulator.of())
+  }
+  if (periodicSimulators.length === 0 && simulators.length === 0) {
     // If no simulators given, enable them all.
     return getSimulators({ ...args, all: true })
   }
-  return simulators
+  return {
+    simulators,
+    periodicSimulators,
+  }
 }
 
 if (require.main === module) {

--- a/src/virtual_robots/simulator.ts
+++ b/src/virtual_robots/simulator.ts
@@ -1,5 +1,11 @@
-export interface Simulator {
+import { NUClearNetClient } from '../shared/nuclearnet/nuclearnet_client'
+
+export interface PeriodicSimulator {
   simulate(time: number, index: number, numRobots: number): Message[]
+}
+
+export interface Simulator {
+  start(network: NUClearNetClient): () => void
 }
 
 export interface Message {

--- a/src/virtual_robots/simulators/chart_data_simulator.ts
+++ b/src/virtual_robots/simulators/chart_data_simulator.ts
@@ -1,11 +1,11 @@
 import { message } from '../../shared/proto/messages'
 import { toTimestamp } from '../../shared/time/timestamp'
-import { Simulator } from '../simulator'
+import { PeriodicSimulator } from '../simulator'
 import { Message } from '../simulator'
 
 import DataPoint = message.support.nusight.DataPoint
 
-export class ChartSimulator implements Simulator {
+export class ChartSimulator implements PeriodicSimulator {
   static of(): ChartSimulator {
     return new ChartSimulator()
   }

--- a/src/virtual_robots/simulators/overview_simulator.ts
+++ b/src/virtual_robots/simulators/overview_simulator.ts
@@ -5,7 +5,7 @@ import { FieldDimensions } from '../../shared/field/dimensions'
 import { message } from '../../shared/proto/messages'
 import { Ivec2 } from '../../shared/proto/messages'
 import { toTimestamp } from '../../shared/time/timestamp'
-import { Simulator } from '../simulator'
+import { PeriodicSimulator } from '../simulator'
 import { Message } from '../simulator'
 import State = message.behaviour.Behaviour.State
 import Mode = message.input.GameState.Data.Mode
@@ -13,7 +13,7 @@ import PenaltyReason = message.input.GameState.Data.PenaltyReason
 import Phase = message.input.GameState.Data.Phase
 import Overview = message.support.nusight.Overview
 
-export class OverviewSimulator implements Simulator {
+export class OverviewSimulator implements PeriodicSimulator {
   constructor(private field: FieldDimensions,
               private random: SeededRandom) {
   }

--- a/src/virtual_robots/simulators/script_data_simulator.ts
+++ b/src/virtual_robots/simulators/script_data_simulator.ts
@@ -1,0 +1,28 @@
+import { NUClearNetPacket } from 'nuclearnet.js'
+
+import { NUClearNetClient } from '../../shared/nuclearnet/nuclearnet_client'
+import { message } from '../../shared/proto/messages'
+import { Simulator } from '../simulator'
+import { Message } from '../simulator'
+import Sensors = message.input.Sensors
+
+export class ScriptDataSimulator implements Simulator {
+  private network?: NUClearNetClient
+
+  static of() {
+    return new ScriptDataSimulator()
+  }
+
+  start(network: NUClearNetClient) {
+    // console.log('ScriptDataSimulator: started')
+    const stop = network.on('message.input.Sensors', this.onSensors)
+
+    return () => {
+      stop()
+    }
+  }
+
+  onSensors(packet: NUClearNetPacket) {
+    // console.log('ScriptDataSimulator: packet received', packet)
+  }
+}

--- a/src/virtual_robots/simulators/sensor_data_simulator.ts
+++ b/src/virtual_robots/simulators/sensor_data_simulator.ts
@@ -4,13 +4,13 @@ import { Quaternion } from 'three'
 
 import { message } from '../../shared/proto/messages'
 import { Imat4 } from '../../shared/proto/messages'
-import { Simulator } from '../simulator'
+import { PeriodicSimulator } from '../simulator'
 import { Message } from '../simulator'
 import Sensors = message.input.Sensors
 
 export const HIP_TO_FOOT = 0.2465
 
-export class SensorDataSimulator implements Simulator {
+export class SensorDataSimulator implements PeriodicSimulator {
   static of() {
     return new SensorDataSimulator()
   }

--- a/src/virtual_robots/simulators/vision_simulator.ts
+++ b/src/virtual_robots/simulators/vision_simulator.ts
@@ -8,7 +8,7 @@ import { Imat4 } from '../../shared/proto/messages'
 import { message } from '../../shared/proto/messages'
 import { toTimestamp } from '../../shared/time/timestamp'
 import { Message } from '../simulator'
-import { Simulator } from '../simulator'
+import { PeriodicSimulator } from '../simulator'
 import CompressedImage = message.output.CompressedImage
 import Projection = message.output.CompressedImage.Lens.Projection
 import Balls = message.vision.Balls
@@ -16,7 +16,7 @@ import Side = message.vision.Goal.Side
 import Team = message.vision.Goal.Team
 import Goals = message.vision.Goals
 
-export class VisionSimulator implements Simulator {
+export class VisionSimulator implements PeriodicSimulator {
   constructor(private images: Uint8Array[]) {
   }
 

--- a/src/virtual_robots/virtual_robots.ts
+++ b/src/virtual_robots/virtual_robots.ts
@@ -1,12 +1,14 @@
 import { range } from '../shared/base/range'
 
+import { Simulator } from './simulator'
 import { VirtualRobot } from './virtual_robot'
-import { SimulatorOpts } from './virtual_robot'
+import { PeriodicSimulatorOpts } from './virtual_robot'
 
 type Opts = {
   fakeNetworking: boolean
   numRobots: number
-  simulators: SimulatorOpts[]
+  simulators: Simulator[]
+  periodicSimulators: PeriodicSimulatorOpts[]
 }
 
 export class VirtualRobots {
@@ -21,6 +23,7 @@ export class VirtualRobots {
       fakeNetworking: opts.fakeNetworking,
       name: `Virtual Robot #${index + 1}`,
       simulators: opts.simulators,
+      periodicSimulators: opts.periodicSimulators,
     }))
     return new VirtualRobots({ robots })
   }


### PR DESCRIPTION
The current setup of the simulators assumes a periodic simulator with a `simulate` method that is called at a regular interval to produce messages to send to NUsight.

This adds support for non-periodic simulators via the following:

- Rename current `Simulator` to `PeriodicSimulator`
- Add `Simulator` interface, with one method `start` which takes the network and returns a stop/cleanup function. In here we can listen for messages and send response messages using the network directly.
- Update `VirtualRobot` to have a list of simulators in addition to periodic simulators. When `startSimulators()` is called, we call `start()` on each simulator, in addition to setting an interval for the periodic simulators. The cleanup functions from `start()` are added to the stops list to be called on exit.

Also added a stub `ScriptDataSimulator` to test the changes, to be fleshed out in #208 when this is merged.