### PR TITLE
Fix storybook console error

### DIFF
--- a/conf/storybook/webpack.config.ts
+++ b/conf/storybook/webpack.config.ts
@@ -12,8 +12,10 @@ export default (storybookConfig: webpack.Configuration) => {
     },
     plugins: [
       ...storybookConfig.plugins || [],
-      ...(config.plugins || []).filter(
-        p => !(p instanceof HtmlWebpackPlugin || p instanceof webpack.HotModuleReplacementPlugin),
+      ...(config.plugins || []).filter(p => !(
+          p instanceof HtmlWebpackPlugin // Storybook handles page generation.
+          || p instanceof webpack.HotModuleReplacementPlugin // Already included in the default storybook plugins.
+        ),
       ),
     ],
     resolve: {

--- a/conf/storybook/webpack.config.ts
+++ b/conf/storybook/webpack.config.ts
@@ -12,7 +12,9 @@ export default (storybookConfig: webpack.Configuration) => {
     },
     plugins: [
       ...storybookConfig.plugins || [],
-      ...(config.plugins || []).filter(p => !(p instanceof HtmlWebpackPlugin)),
+      ...(config.plugins || []).filter(
+        p => !(p instanceof HtmlWebpackPlugin || p instanceof webpack.HotModuleReplacementPlugin),
+      ),
     ],
     resolve: {
       ...storybookConfig.resolve,


### PR DESCRIPTION
`HotModuleReplacementPlugin` already included by `storybookConfig.plugins`, so we filter it out of `config.plugins`