### PR TITLE
Specifies version number for node.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 ## Dependencies
-- [Node](https://nodejs.org/en/download/)
+- [Node v10.16](https://nodejs.org/en/download/)
 - [Yarn](https://yarnpkg.com/en/docs/install)
 
 ## Installing

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "repository": "github:NUbots/NUsight2",
   "engines": {
-    "node": ">=4.X.X",
+    "node": ">=10.0.0 <11.0.0",
     "yarn": "1.x"
   },
   "scripts": {


### PR DESCRIPTION
Installing the newest version of node (v12) results in compilation errors for NUClearNet.js. v10 is known to work (travis also uses v10 for testing). 