### PR TITLE
Add ability to toggle vision objects

### DIFF
--- a/src/client/components/switches_menu/menu_icon.svg
+++ b/src/client/components/switches_menu/menu_icon.svg
@@ -1,0 +1,2 @@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>

--- a/src/client/components/switches_menu/menu_icon.svg
+++ b/src/client/components/switches_menu/menu_icon.svg
@@ -1,2 +1,1 @@
-
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>

--- a/src/client/components/switches_menu/stories/switches_menu.stories.tsx
+++ b/src/client/components/switches_menu/stories/switches_menu.stories.tsx
@@ -7,53 +7,47 @@ import * as React from 'react'
 import { SwitchesMenu, SwitchesMenuOption } from '../view'
 
 const actions = {
-  onToggleOption: action('onToggleOption'),
+  toggle: action('toggle'),
 }
 
 storiesOf('components.switches_menu', module)
   .addDecorator(story => <div style={{ maxWidth: '350px' }}>{story()}</div>)
   .add('renders empty', () => {
-    return <SwitchesMenu
-      options={[]}
-      toggleOption={actions.onToggleOption}
-    />
+    return <SwitchesMenu options={[]} />
   })
   .add('renders with options', () => {
-    const options = getOptions()
-    return <SwitchesMenu
-      options={options}
-      toggleOption={actions.onToggleOption}
-    />
+    return <SwitchesMenu options={getOptions()} />
   })
   .add('dropdown right', () => {
-    const options = getOptions()
     const style = { backgroundColor: '#eee', display: 'flex', justifyContent: 'flex-end' }
     return <div style={style}>
       <SwitchesMenu
-        options={options}
+        options={getOptions()}
         dropdownMenuPosition='right'
-        toggleOption={actions.onToggleOption}
       />
     </div>
   })
   .add('interactive', () => {
-    const options = getOptions()
     const model = observable({
-      options,
+      options: getOptions().map(({ label, enabled }: SwitchesMenuOption, i) => {
+        return {
+          label,
+          enabled,
+          toggle: mobxAction(() => {
+            model.options[i].enabled = !model.options[i].enabled
+          }),
+        }
+      }),
     })
-    const onChange = mobxAction((option: SwitchesMenuOption) => option.enabled = !option.enabled)
-    const Component = observer(() => <SwitchesMenu
-      options={model.options}
-      toggleOption={onChange}
-    />)
+    const Component = observer(() => <SwitchesMenu options={model.options} />)
 
     return <Component />
   })
 
 function getOptions(): SwitchesMenuOption[] {
   return [
-    { label: 'Lines', enabled: true },
-    { label: 'Balls', enabled: true },
-    { label: 'Goals', enabled: false },
+    { label: 'Lines', enabled: true, toggle: actions.toggle },
+    { label: 'Balls', enabled: true, toggle: actions.toggle },
+    { label: 'Goals', enabled: false, toggle: actions.toggle },
   ]
 }

--- a/src/client/components/switches_menu/stories/switches_menu.stories.tsx
+++ b/src/client/components/switches_menu/stories/switches_menu.stories.tsx
@@ -1,0 +1,59 @@
+import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import { action as mobxAction, observable } from 'mobx'
+import { observer } from 'mobx-react'
+import * as React from 'react'
+
+import { SwitchesMenuOption, SwitchesMenu } from '../view'
+
+const actions = {
+  onToggleOption: action('onToggleOption'),
+}
+
+storiesOf('components.switches_menu', module)
+  .addDecorator(story => <div style={{ maxWidth: '350px' }}>{story()}</div>)
+  .add('renders empty', () => {
+    return <SwitchesMenu
+      options={[]}
+      toggleOption={actions.onToggleOption}
+    />
+  })
+  .add('renders with options', () => {
+    const options = getOptions()
+    return <SwitchesMenu
+      options={options}
+      toggleOption={actions.onToggleOption}
+    />
+  })
+  .add('dropdown right', () => {
+    const options = getOptions()
+    const style = { backgroundColor: '#eee', display: 'flex', justifyContent: 'flex-end' }
+    return <div style={style}>
+      <SwitchesMenu
+        options={options}
+        dropdownMenuPosition='right'
+        toggleOption={actions.onToggleOption}
+      />
+    </div>
+  })
+  .add('interactive', () => {
+    const options = getOptions()
+    const model = observable({
+      options,
+    })
+    const onChange = mobxAction((option: SwitchesMenuOption) => option.enabled = !option.enabled)
+    const Component = observer(() => <SwitchesMenu
+      options={model.options}
+      toggleOption={onChange}
+    />)
+
+    return <Component />
+  })
+
+function getOptions(): SwitchesMenuOption[] {
+  return [
+    { label: 'Lines', enabled: true },
+    { label: 'Balls', enabled: true },
+    { label: 'Goals', enabled: false },
+  ]
+}

--- a/src/client/components/switches_menu/stories/switches_menu.stories.tsx
+++ b/src/client/components/switches_menu/stories/switches_menu.stories.tsx
@@ -4,7 +4,7 @@ import { action as mobxAction, observable } from 'mobx'
 import { observer } from 'mobx-react'
 import * as React from 'react'
 
-import { SwitchesMenuOption, SwitchesMenu } from '../view'
+import { SwitchesMenu, SwitchesMenuOption } from '../view'
 
 const actions = {
   onToggleOption: action('onToggleOption'),

--- a/src/client/components/switches_menu/style.css
+++ b/src/client/components/switches_menu/style.css
@@ -1,0 +1,70 @@
+.button {
+  align-items: center;
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.7rem;
+  height: 56px;
+  justify-content: center;
+  outline: 0;
+  padding: 0 1em;
+  transition: background-color 0.3s ease;
+}
+
+.button:hover {
+  background-color: #f9f9f9;
+}
+
+.button > svg {
+  fill: #1197d3;
+  height: 2.85em;
+  margin: 0 auto;
+  padding: 0.25em;
+  transition: fill 0.25s ease-out;
+  width: auto;
+}
+
+.button:hover > svg {
+  fill: #0d76a6;
+}
+
+.empty {
+  color: #888;
+  padding: 1em;
+  min-width: 132px;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.options {
+  background-color: white;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  box-shadow:
+    0px 0px 3px 0px rgba(0, 0, 0, 0.15),
+    0px 3px 8px 0px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  width: 100%;
+  min-width: 132px;
+}
+
+.option {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: 1em;
+}
+
+.option:hover {
+  background-color: #eee;
+  cursor: pointer;
+}
+
+.optionLabel {
+  margin-right: 1em;
+  white-space: nowrap;
+}

--- a/src/client/components/switches_menu/view.tsx
+++ b/src/client/components/switches_menu/view.tsx
@@ -1,0 +1,53 @@
+import { observer } from 'mobx-react'
+import * as React from 'react'
+
+import { dropdownContainer } from '../dropdown_container/view'
+import { Switch } from '../switch/view'
+
+import MenuIcon from './menu_icon.svg'
+import * as style from './style.css'
+
+export type SwitchesMenuOption = {
+  label: string
+  enabled: boolean
+  toggle?(): void
+}
+
+export type SwitchesMenuProps = {
+  dropdownMenuPosition?: 'left' | 'right'
+  options: SwitchesMenuOption[]
+  toggleOption(option: SwitchesMenuOption): void
+}
+
+export const SwitchesMenu = observer((props: SwitchesMenuProps) => {
+  const { options, toggleOption } = props
+  const dropdownToggle = (
+    <button className={style.button}>
+      <MenuIcon />
+    </button>
+  )
+  const onChange = (option: SwitchesMenuOption) => () => toggleOption(option)
+  return (
+    <div className={style.switchesMenu}>
+      <EnhancedDropdown dropdownToggle={dropdownToggle} dropdownPosition={props.dropdownMenuPosition}>
+        <div className={style.options}>
+          {options.length === 0 &&
+            <div className={style.empty}>
+              No options
+            </div>
+          }
+          {options.map(option => {
+            return (
+              <label key={option.label} className={style.option}>
+                <span className={style.optionLabel}>{option.label}</span>
+                <Switch on={option.enabled} onChange={onChange(option)} />
+              </label>
+            )
+          })}
+        </div>
+      </EnhancedDropdown>
+    </div>
+  )
+})
+
+const EnhancedDropdown = dropdownContainer()

--- a/src/client/components/switches_menu/view.tsx
+++ b/src/client/components/switches_menu/view.tsx
@@ -10,23 +10,21 @@ import * as style from './style.css'
 export type SwitchesMenuOption = {
   label: string
   enabled: boolean
-  toggle?(): void
+  toggle(): void
 }
 
 export type SwitchesMenuProps = {
   dropdownMenuPosition?: 'left' | 'right'
   options: SwitchesMenuOption[]
-  toggleOption(option: SwitchesMenuOption): void
 }
 
 export const SwitchesMenu = observer((props: SwitchesMenuProps) => {
-  const { options, toggleOption } = props
+  const { options } = props
   const dropdownToggle = (
     <button className={style.button}>
       <MenuIcon />
     </button>
   )
-  const onChange = (option: SwitchesMenuOption) => () => toggleOption(option)
   return (
     <div className={style.switchesMenu}>
       <EnhancedDropdown dropdownToggle={dropdownToggle} dropdownPosition={props.dropdownMenuPosition}>
@@ -40,7 +38,7 @@ export const SwitchesMenu = observer((props: SwitchesMenuProps) => {
             return (
               <label key={option.label} className={style.option}>
                 <span className={style.optionLabel}>{option.label}</span>
-                <Switch on={option.enabled} onChange={onChange(option)} />
+                <Switch on={option.enabled} onChange={option.toggle} />
               </label>
             )
           })}

--- a/src/client/components/vision/camera/model.ts
+++ b/src/client/components/vision/camera/model.ts
@@ -1,3 +1,5 @@
+import { action } from 'mobx'
+import { computed } from 'mobx'
 import { observable } from 'mobx'
 
 import { Image } from '../../../image_decoder/image_decoder'
@@ -49,6 +51,50 @@ export class CameraModel {
   @observable.ref balls: Ball[]
   @observable.ref goals: Goal[]
   @observable.ref name: string
+  @observable draw = {
+    image: true,
+    compass: true,
+    horizon: true,
+    visualmesh: true,
+    balls: true,
+    goals: true,
+  }
+
+  @computed
+  get drawOptions() {
+    return [
+      {
+        label: 'Image',
+        enabled: this.draw.image,
+        toggle: action(() => this.draw.image = !this.draw.image),
+      },
+      {
+        label: 'Compass',
+        enabled: this.draw.compass,
+        toggle: action(() => this.draw.compass = !this.draw.compass),
+      },
+      {
+        label: 'Horizon',
+        enabled: this.draw.horizon,
+        toggle: action(() => this.draw.horizon = !this.draw.horizon),
+      },
+      {
+        label: 'Visual Mesh',
+        enabled: this.draw.visualmesh,
+        toggle: action(() => this.draw.visualmesh = !this.draw.visualmesh),
+      },
+      {
+        label: 'Balls',
+        enabled: this.draw.balls,
+        toggle: action(() => this.draw.balls = !this.draw.balls),
+      },
+      {
+        label: 'Goals',
+        enabled: this.draw.goals,
+        toggle: action(() => this.draw.goals = !this.draw.goals),
+      },
+    ]
+  }
 
   constructor(private model: VisionRobotModel, { id, name, balls, goals }: {
     id: number

--- a/src/client/components/vision/camera/view.tsx
+++ b/src/client/components/vision/camera/view.tsx
@@ -24,7 +24,7 @@ export class CameraView extends Component<{ viewModel: CameraViewModel }> {
   }
 
   render() {
-    const { imageWidth, imageHeight } = this.props.viewModel
+    const { imageWidth, imageHeight, drawOptions } = this.props.viewModel
 
     if (!imageWidth || !imageHeight) {
       return null
@@ -32,7 +32,6 @@ export class CameraView extends Component<{ viewModel: CameraViewModel }> {
 
     const aspectRatio = imageWidth / imageHeight
     const percentage = 60
-    const toggleOption = action((option: SwitchesMenuOption) => option.enabled = !option.enabled)
 
     return (
       <div
@@ -48,13 +47,7 @@ export class CameraView extends Component<{ viewModel: CameraViewModel }> {
         <div style={{ position: 'absolute', top: '0', right: '0' }}>
           <SwitchesMenu
             dropdownMenuPosition='right'
-            options={Object.entries(this.props.viewModel.draw).map(([key, value]) => {
-              return {
-                label: key,
-                enabled: value,
-              }
-            })}
-            toggleOption={toggleOption}
+            options={drawOptions}
           />
         </div>
       </div>

--- a/src/client/components/vision/camera/view.tsx
+++ b/src/client/components/vision/camera/view.tsx
@@ -1,5 +1,5 @@
 import { autorun } from 'mobx'
-import { action, observable } from 'mobx'
+import { action } from 'mobx'
 import { observer } from 'mobx-react'
 import * as React from 'react'
 import { Component } from 'react'
@@ -31,7 +31,7 @@ export class CameraView extends Component<{ viewModel: CameraViewModel }> {
 
     const aspectRatio = imageWidth / imageHeight
     const percentage = 60
-    const toggleOption = action((option: SwitchesMenuOption) => option!.toggle())
+    const toggleOption = action((option: SwitchesMenuOption) => option.enabled = !option.enabled)
 
     return (
       <div
@@ -48,11 +48,10 @@ export class CameraView extends Component<{ viewModel: CameraViewModel }> {
           <SwitchesMenu
             dropdownMenuPosition='right'
             options={Object.entries(this.props.viewModel.draw).map(([key, value]) => {
-              return observable({
+              return {
                 label: key,
                 enabled: value,
-                toggle: action(() => this.props.viewModel.draw[key] = !this.props.viewModel.draw[key])
-              })
+              }
             })}
             toggleOption={toggleOption}
           />

--- a/src/client/components/vision/camera/view.tsx
+++ b/src/client/components/vision/camera/view.tsx
@@ -1,11 +1,12 @@
 import { autorun } from 'mobx'
-import { action } from 'mobx'
+import { action, observable } from 'mobx'
 import { observer } from 'mobx-react'
 import * as React from 'react'
 import { Component } from 'react'
 import ReactResizeDetector from 'react-resize-detector'
 
 import { CameraViewModel } from './view_model'
+import { SwitchesMenu, SwitchesMenuOption } from '../../switches_menu/view'
 
 @observer
 export class CameraView extends Component<{ viewModel: CameraViewModel }> {
@@ -30,6 +31,8 @@ export class CameraView extends Component<{ viewModel: CameraViewModel }> {
 
     const aspectRatio = imageWidth / imageHeight
     const percentage = 60
+    const toggleOption = action((option: SwitchesMenuOption) => option!.toggle())
+
     return (
       <div
         style={{
@@ -37,9 +40,23 @@ export class CameraView extends Component<{ viewModel: CameraViewModel }> {
           height: `${percentage / aspectRatio}vw`,
           maxHeight: `${percentage}vh`,
           maxWidth: `${percentage * aspectRatio}vh`,
+          position: 'relative'
         }}>
         <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
         <canvas ref={this.onRef} />
+        <div style={{position: 'absolute', top: '0', right: '0'}}>
+          <SwitchesMenu
+            dropdownMenuPosition='right'
+            options={Object.entries(this.props.viewModel.draw).map(([key, value]) => {
+              return observable({
+                label: key,
+                enabled: value,
+                toggle: action(() => this.props.viewModel.draw[key] = !this.props.viewModel.draw[key])
+              })
+            })}
+            toggleOption={toggleOption}
+          />
+        </div>
       </div>
     )
   }

--- a/src/client/components/vision/camera/view.tsx
+++ b/src/client/components/vision/camera/view.tsx
@@ -5,8 +5,9 @@ import * as React from 'react'
 import { Component } from 'react'
 import ReactResizeDetector from 'react-resize-detector'
 
-import { CameraViewModel } from './view_model'
 import { SwitchesMenu, SwitchesMenuOption } from '../../switches_menu/view'
+
+import { CameraViewModel } from './view_model'
 
 @observer
 export class CameraView extends Component<{ viewModel: CameraViewModel }> {
@@ -40,11 +41,11 @@ export class CameraView extends Component<{ viewModel: CameraViewModel }> {
           height: `${percentage / aspectRatio}vw`,
           maxHeight: `${percentage}vh`,
           maxWidth: `${percentage * aspectRatio}vh`,
-          position: 'relative'
+          position: 'relative',
         }}>
         <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
         <canvas ref={this.onRef} />
-        <div style={{position: 'absolute', top: '0', right: '0'}}>
+        <div style={{ position: 'absolute', top: '0', right: '0' }}>
           <SwitchesMenu
             dropdownMenuPosition='right'
             options={Object.entries(this.props.viewModel.draw).map(([key, value]) => {

--- a/src/client/components/vision/camera/view_model.ts
+++ b/src/client/components/vision/camera/view_model.ts
@@ -37,14 +37,6 @@ export class CameraViewModel {
   @observable.ref canvas: HTMLCanvasElement | null = null
   @observable viewWidth?: number
   @observable viewHeight?: number
-  @observable draw = {
-    image: true,
-    compass: true,
-    horizon: true,
-    visualmesh: true,
-    balls: true,
-    goals: true,
-  }
 
   readonly camera: Camera
   readonly destroy: () => void
@@ -84,6 +76,11 @@ export class CameraViewModel {
   }
 
   @computed
+  get drawOptions() {
+    return this.model.drawOptions
+  }
+
+  @computed
   private get decoder() {
     return ImageDecoder.of(this.renderer(this.canvas)!)
   }
@@ -98,15 +95,15 @@ export class CameraViewModel {
     const scene = this.scene
     scene.remove(...scene.children)
     if (this.model.image) {
-      this.draw.image && scene.add(this.image)
-      this.draw.compass && scene.add(this.compass(this.model.image.Hcw))
-      this.draw.horizon && scene.add(this.horizon(this.model.image.Hcw))
+      this.model.draw.image && scene.add(this.image)
+      this.model.draw.compass && scene.add(this.compass(this.model.image.Hcw))
+      this.model.draw.horizon && scene.add(this.horizon(this.model.image.Hcw))
     }
-    if (this.model.visualmesh && this.draw.visualmesh) {
+    if (this.model.visualmesh && this.model.draw.visualmesh) {
       scene.add(this.visualmesh(this.model.visualmesh))
     }
-    this.draw.balls && this.model.balls.forEach(ball => scene.add(this.ball(ball)))
-    this.draw.goals && this.model.goals.forEach(goal => scene.add(this.goal(goal)))
+    this.model.draw.balls && this.model.balls.forEach(ball => scene.add(this.ball(ball)))
+    this.model.draw.goals && this.model.goals.forEach(goal => scene.add(this.goal(goal)))
     return scene
   }
 

--- a/src/client/components/vision/camera/view_model.ts
+++ b/src/client/components/vision/camera/view_model.ts
@@ -37,6 +37,14 @@ export class CameraViewModel {
   @observable.ref canvas: HTMLCanvasElement | null = null
   @observable viewWidth?: number
   @observable viewHeight?: number
+  @observable draw = {
+    image: true,
+    compass: true,
+    horizon: true,
+    visualmesh: true,
+    balls: true,
+    goals: true,
+  }
 
   readonly camera: Camera
   readonly destroy: () => void
@@ -55,6 +63,8 @@ export class CameraViewModel {
     this.destroy = autorun(() => {
       this.canvas && this.decoder.update(this.model.image!)
     })
+
+    console.log(this.model)
   }
 
   static of = createTransformer((model: CameraModel) => {
@@ -67,6 +77,7 @@ export class CameraViewModel {
 
   @computed
   get id(): number {
+    console.log(this, this.model)
     return this.model.id
   }
 
@@ -90,15 +101,15 @@ export class CameraViewModel {
     const scene = this.scene
     scene.remove(...scene.children)
     if (this.model.image) {
-      scene.add(this.image)
-      scene.add(this.compass(this.model.image.Hcw))
-      scene.add(this.horizon(this.model.image.Hcw))
+      this.draw.image && scene.add(this.image)
+      this.draw.compass && scene.add(this.compass(this.model.image.Hcw))
+      this.draw.horizon && scene.add(this.horizon(this.model.image.Hcw))
     }
-    if (this.model.visualmesh) {
+    if (this.model.visualmesh && this.draw.visualmesh) {
       scene.add(this.visualmesh(this.model.visualmesh))
     }
-    this.model.balls.forEach(ball => scene.add(this.ball(ball)))
-    this.model.goals.forEach(goal => scene.add(this.goal(goal)))
+    this.draw.balls && this.model.balls.forEach(ball => scene.add(this.ball(ball)))
+    this.draw.goals && this.model.goals.forEach(goal => scene.add(this.goal(goal)))
     return scene
   }
 

--- a/src/client/components/vision/camera/view_model.ts
+++ b/src/client/components/vision/camera/view_model.ts
@@ -63,8 +63,6 @@ export class CameraViewModel {
     this.destroy = autorun(() => {
       this.canvas && this.decoder.update(this.model.image!)
     })
-
-    console.log(this.model)
   }
 
   static of = createTransformer((model: CameraModel) => {
@@ -77,7 +75,6 @@ export class CameraViewModel {
 
   @computed
   get id(): number {
-    console.log(this, this.model)
     return this.model.id
   }
 

--- a/src/virtual_robots/simulators/vision_simulator.ts
+++ b/src/virtual_robots/simulators/vision_simulator.ts
@@ -61,7 +61,7 @@ export class VisionSimulator extends Simulator {
         Hcw: toProtoMat44(Hcw),
         lens: {
           projection: Projection.RECTILINEAR,
-          focalLength: 1,
+          focalLength: 712,
           fov: 1,
         },
       }).finish(),


### PR DESCRIPTION
This PR adds a dropdown menu on each camera image that allows for toggling the objects drawn (image, horizon, visual mesh, balls, goals, etc).

For the dropdown menu, I've added a new component `SwitchesMenu` which renders a dropdown menu where every option has a switch that can be toggled.

Storybook: https://nusight-pr-264.herokuapp.com/storybook/?path=/story/components-switches-menu--renders-empty