### PR TITLE
Add robot connection indicator

### DIFF
--- a/src/client/components/robot_selector/stories/robot_selector.stories.tsx
+++ b/src/client/components/robot_selector/stories/robot_selector.stories.tsx
@@ -1,0 +1,69 @@
+import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import { action as mobxAction, observable } from 'mobx'
+import { observer } from 'mobx-react'
+import * as React from 'react'
+
+import { RobotModel } from '../../robot/model'
+import { RobotSelector } from '../view'
+
+const actions = {
+  selectRobot: action('selectRobot'),
+}
+
+storiesOf('components.robot_selector', module)
+  .addDecorator(story => <div style={{ maxWidth: '320px' }}>{story()}</div>)
+  .add('renders empty', () => {
+    return <RobotSelector
+      robots={[]}
+      selectRobot={actions.selectRobot}
+    />
+  })
+  .add('renders with robots', () => {
+    const robots = getRobots()
+    return <RobotSelector
+      robots={robots}
+      selectRobot={actions.selectRobot}
+    />
+  })
+  .add('interactive', () => {
+    const robots = getRobots()
+    const model = observable({
+      robots,
+    })
+    const selectRobot = mobxAction((robot: RobotModel) => robot.enabled = !robot.enabled)
+    const Component = observer(() => <RobotSelector
+      robots={model.robots}
+      selectRobot={selectRobot}
+    />)
+    return <Component/>
+  })
+
+function getRobots(): RobotModel[] {
+  return [
+    {
+      id: '1',
+      name: 'Virtual Robot 1',
+      connected: true,
+      enabled: true,
+      address: '',
+      port: 0,
+    },
+    {
+      id: '2',
+      name: 'Virtual Robot 2',
+      connected: true,
+      enabled: true,
+      address: '',
+      port: 0,
+    },
+    {
+      id: '3',
+      name: 'Virtual Robot 3',
+      connected: false,
+      enabled: true,
+      address: '',
+      port: 0,
+    },
+  ]
+}

--- a/src/client/components/robot_selector/style.css
+++ b/src/client/components/robot_selector/style.css
@@ -84,6 +84,22 @@
   cursor: pointer;
 }
 
+.robotConnectionIndicator {
+  box-sizing: border-box;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  margin-right: 0.75em;
+}
+
+.robotConnected {
+  background-color: #00de46;
+}
+
+.robotDisconnected {
+  border: 2px solid #ccc;
+}
+
 .robotLabel {
   margin-right: 1em;
   white-space: nowrap;

--- a/src/client/components/robot_selector/view.tsx
+++ b/src/client/components/robot_selector/view.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames'
 import { observer } from 'mobx-react'
 import * as React from 'react'
 
@@ -42,8 +43,13 @@ export const RobotSelector = observer((props: RobotSelectorProps) => {
             </div>
           }
           {robots.map(robot => {
+            const indicatorClassName = classNames(style.robotConnectionIndicator, {
+              [style.robotConnected]: robot.connected,
+              [style.robotDisconnected]: !robot.connected,
+            })
             return (
               <label key={robot.id} className={style.robot}>
+                <span className={indicatorClassName} title={robot.connected ? 'Connected' : 'Disconnected'}></span>
                 <span className={style.robotLabel}>{robot.name}</span>
                 <Switch on={robot.enabled} onChange={onChange(robot)} />
               </label>


### PR DESCRIPTION
This adds a connection indicator to the robot selector:

<img src="https://user-images.githubusercontent.com/5924865/59849398-d8a62000-93aa-11e9-8a17-91b85b06bf25.png" alt="Screenshot of robot selector with connection indicator" width="200px">

Green = connected
Gray outline = disconnected

Also adds stories for the robot selector component, since that was written before we had Storybook.

Storybook: https://nusight-pr-268.herokuapp.com/storybook/?path=/story/components-robot-selector--renders-empty