### PR TITLE
Fix storybook

### DIFF
--- a/conf/storybook/build_storybook.js
+++ b/conf/storybook/build_storybook.js
@@ -3,6 +3,6 @@ const storybook = require('@storybook/react/standalone')
 storybook({
   mode: 'static',
   staticDir: ['src/assets'],
-  outputDir: 'dist/storybook',
+  outputDir: 'dist/public/storybook',
   configDir: __dirname,
 })

--- a/conf/storybook/webpack.config.ts
+++ b/conf/storybook/webpack.config.ts
@@ -1,6 +1,7 @@
-import HtmlWebpackPlugin from 'html-webpack-plugin'
 import CopyWebpackPlugin from 'copy-webpack-plugin'
+import HtmlWebpackPlugin from 'html-webpack-plugin'
 import * as path from 'path'
+import ProgressBarPlugin from 'progress-bar-webpack-plugin'
 import webpack from 'webpack'
 import { getClientConfig } from '../../webpack.config'
 
@@ -22,6 +23,7 @@ export default ({ config: storybookConfig }: { config: webpack.Configuration }) 
       ...(config.plugins || []).filter(p => !(
           p instanceof HtmlWebpackPlugin // Storybook handles page generation.
           || p instanceof CopyWebpackPlugin // Avoids overwriting index.html.
+          || p instanceof ProgressBarPlugin // Storybook already has a progress plugin.
         ),
       ),
     ],

--- a/conf/storybook/webpack.config.ts
+++ b/conf/storybook/webpack.config.ts
@@ -1,4 +1,5 @@
 import HtmlWebpackPlugin from 'html-webpack-plugin'
+import CopyWebpackPlugin from 'copy-webpack-plugin'
 import * as path from 'path'
 import webpack from 'webpack'
 import { getClientConfig } from '../../webpack.config'
@@ -20,7 +21,7 @@ export default ({ config: storybookConfig }: { config: webpack.Configuration }) 
       ...storybookConfig.plugins || [],
       ...(config.plugins || []).filter(p => !(
           p instanceof HtmlWebpackPlugin // Storybook handles page generation.
-          || p instanceof webpack.HotModuleReplacementPlugin // Already included in the default storybook plugins.
+          || p instanceof CopyWebpackPlugin // Avoids overwriting index.html.
         ),
       ),
     ],


### PR DESCRIPTION
1. `CopyWebpackPlugin` was overwriting `index.html` producing a blank page
2. `HotModuleReplacementPlugin` isn't used anymore, so replacing that