### PR TITLE
Add math three.js helpers

### DIFF
--- a/src/client/math/matrix2.ts
+++ b/src/client/math/matrix2.ts
@@ -1,3 +1,5 @@
+import * as THREE from 'three'
+
 import { Vector2 } from './vector2'
 
 export class Matrix2 {
@@ -27,4 +29,13 @@ export class Matrix2 {
   get trace(): number {
     return this.x.x + this.y.y
   }
+
+  toString() {
+    return [
+      `${format(this.x.x)} ${format(this.y.x)}`,
+      `${format(this.x.y)} ${format(this.y.y)}`,
+    ].join('\n')
+  }
 }
+
+const format = (x: number) => x.toFixed(2).padStart(7)

--- a/src/client/math/matrix3.ts
+++ b/src/client/math/matrix3.ts
@@ -1,3 +1,5 @@
+import * as THREE from 'three'
+
 import { Vector3 } from './vector3'
 
 export class Matrix3 {
@@ -30,4 +32,30 @@ export class Matrix3 {
   get trace(): number {
     return this.x.x + this.y.y + this.z.z
   }
+
+  static fromThree(mat4: THREE.Matrix3) {
+    return new Matrix3(
+      new Vector3(mat4.elements[0], mat4.elements[1], mat4.elements[2]),
+      new Vector3(mat4.elements[3], mat4.elements[4], mat4.elements[5]),
+      new Vector3(mat4.elements[6], mat4.elements[7], mat4.elements[8]),
+    )
+  }
+
+  toThree(): THREE.Matrix3 {
+    return new THREE.Matrix3().set(
+      this.x.x, this.y.x, this.z.x,
+      this.x.y, this.y.y, this.z.y,
+      this.x.z, this.y.z, this.z.z,
+    )
+  }
+
+  toString() {
+    return [
+      `${format(this.x.x)} ${format(this.y.x)} ${format(this.z.x)}`,
+      `${format(this.x.y)} ${format(this.y.y)} ${format(this.z.y)}`,
+      `${format(this.x.z)} ${format(this.y.z)} ${format(this.z.z)}`,
+    ].join('\n')
+  }
 }
+
+const format = (x: number) => x.toFixed(2).padStart(7)

--- a/src/client/math/matrix4.ts
+++ b/src/client/math/matrix4.ts
@@ -1,3 +1,5 @@
+import * as THREE from 'three'
+
 import { Vector4 } from './vector4'
 
 export class Matrix4 {
@@ -33,4 +35,33 @@ export class Matrix4 {
   get trace(): number {
     return this.x.x + this.y.y + this.z.z + this.t.t
   }
+
+  static fromThree(mat4: THREE.Matrix4) {
+    return new Matrix4(
+      new Vector4(mat4.elements[0], mat4.elements[1], mat4.elements[2], mat4.elements[3]),
+      new Vector4(mat4.elements[4], mat4.elements[5], mat4.elements[6], mat4.elements[7]),
+      new Vector4(mat4.elements[8], mat4.elements[9], mat4.elements[10], mat4.elements[11]),
+      new Vector4(mat4.elements[12], mat4.elements[13], mat4.elements[14], mat4.elements[15]),
+    )
+  }
+
+  toThree(): THREE.Matrix4 {
+    return new THREE.Matrix4().set(
+      this.x.x, this.y.x, this.z.x, this.t.x,
+      this.x.y, this.y.y, this.z.y, this.t.y,
+      this.x.z, this.y.z, this.z.z, this.t.z,
+      this.x.t, this.y.t, this.z.t, this.t.t,
+    )
+  }
+
+  toString() {
+    return [
+      `${format(this.x.x)} ${format(this.y.x)} ${format(this.z.x)} ${format(this.t.x)}`,
+      `${format(this.x.y)} ${format(this.y.y)} ${format(this.z.y)} ${format(this.t.y)}`,
+      `${format(this.x.z)} ${format(this.y.z)} ${format(this.z.z)} ${format(this.t.z)}`,
+      `${format(this.x.t)} ${format(this.y.t)} ${format(this.z.t)} ${format(this.t.t)}`,
+    ].join('\n')
+  }
 }
+
+const format = (x: number) => x.toFixed(2).padStart(7)

--- a/src/client/math/vector2.ts
+++ b/src/client/math/vector2.ts
@@ -1,3 +1,5 @@
+import * as THREE from 'three'
+
 import { Transform } from './transform'
 
 export class Vector2 {
@@ -71,5 +73,17 @@ export class Vector2 {
 
   subtract(v: Vector2): Vector2 {
     return new Vector2(this.x - v.x, this.y - v.y)
+  }
+
+  static fromThree(vec2: THREE.Vector2): Vector2 {
+    return new Vector2(vec2.x, vec2.y)
+  }
+
+  toThree(): THREE.Vector2 {
+    return new THREE.Vector2(this.x, this.y)
+  }
+
+  toString() {
+    return `(${this.x}, ${this.y})`
   }
 }

--- a/src/client/math/vector3.ts
+++ b/src/client/math/vector3.ts
@@ -1,3 +1,5 @@
+import * as THREE from 'three'
+
 export class Vector3 {
   constructor(
     readonly x: number,
@@ -48,6 +50,18 @@ export class Vector3 {
 
   subtract(v: Vector3): Vector3 {
     return new Vector3(this.x - v.x, this.y - v.y, this.z - v.z)
+  }
+
+  static fromThree(vec3: THREE.Vector3): Vector3 {
+    return new Vector3(vec3.x, vec3.y, vec3.z)
+  }
+
+  toThree(): THREE.Vector3 {
+    return new THREE.Vector3(this.x, this.y, this.z)
+  }
+
+  toString() {
+    return `(${this.x}, ${this.y}, ${this.z})`
   }
 }
 

--- a/src/client/math/vector4.ts
+++ b/src/client/math/vector4.ts
@@ -51,7 +51,7 @@ export class Vector4 {
     return new Vector4(this.x - v.x, this.y - v.y, this.z - v.z, this.t - v.t)
   }
 
-  vec3() {
+  vec3(): Vector3 {
     return new Vector3(this.x, this.y, this.z)
   }
 

--- a/src/client/math/vector4.ts
+++ b/src/client/math/vector4.ts
@@ -1,3 +1,7 @@
+import * as THREE from 'three'
+
+import { Vector3 } from './vector3'
+
 export class Vector4 {
   constructor(
     readonly x: number,
@@ -45,5 +49,21 @@ export class Vector4 {
 
   subtract(v: Vector4): Vector4 {
     return new Vector4(this.x - v.x, this.y - v.y, this.z - v.z, this.t - v.t)
+  }
+
+  vec3() {
+    return new Vector3(this.x, this.y, this.z)
+  }
+
+  static fromThree(vec4: THREE.Vector4): Vector4 {
+    return new Vector4(vec4.x, vec4.y, vec4.z, vec4.w)
+  }
+
+  toThree(): THREE.Vector4 {
+    return new THREE.Vector4(this.x, this.y, this.z, this.t)
+  }
+
+  toString() {
+    return `(${this.x}, ${this.y}, ${this.z}, ${this.t})`
   }
 }


### PR DESCRIPTION
Since we do it everywhere, this PR at least makes it relatively easy to convert between the types.

Added some `toString` helpers as well.

(p.s. if only we had typeclasses)