### PR TITLE
Extend three builders

### DIFF
--- a/src/client/components/classifier/classified_image/view_model.ts
+++ b/src/client/components/classifier/classified_image/view_model.ts
@@ -9,6 +9,7 @@ import { Matrix4 } from 'three'
 import { PlaneGeometry } from 'three'
 
 import { disposableComputed } from '../../../base/disposable_computed'
+import { rawShader } from '../../three/builders'
 import { dataTexture } from '../../three/builders'
 import { shaderMaterial } from '../../three/builders'
 import { imageTexture } from '../../three/builders'
@@ -58,8 +59,7 @@ export class ClassifiedImageViewModel {
   })
 
   private readonly material = shaderMaterial(() => ({
-    vertexShader,
-    fragmentShader,
+    shader: this.shader,
     uniforms: {
       image: { value: this.imageTexture() },
       lut: { value: this.lutTexture() },
@@ -69,6 +69,8 @@ export class ClassifiedImageViewModel {
       bitsZ: { value: this.model.lut.size.z },
     },
   }))
+
+  private readonly shader = rawShader(() => ({ vertexShader, fragmentShader }))
 
   private readonly imageTexture = imageTexture(() => ({
     image: this.imageElement,

--- a/src/client/components/classifier/visualizer/view_model.ts
+++ b/src/client/components/classifier/visualizer/view_model.ts
@@ -10,6 +10,7 @@ import { Texture } from 'three'
 
 import { disposableComputed } from '../../../base/disposable_computed'
 import { Vector3 } from '../../../math/vector3'
+import { rawShader } from '../../three/builders'
 import { dataTexture } from '../../three/builders'
 import { shaderMaterial } from '../../three/builders'
 import { perspectiveCamera } from '../../three/builders'
@@ -91,8 +92,7 @@ export class VisualizerViewModel {
   }
 
   private readonly planeMaterial = shaderMaterial(() => ({
-    vertexShader,
-    fragmentShader,
+    shader: this.shader,
     uniforms: {
       lut: { value: this.lutTexture() },
       lutSize: { value: this.lutSize },
@@ -103,6 +103,8 @@ export class VisualizerViewModel {
       size: { value: this.canvas.height / this.model.lut.size.z / 7 },
     },
   }))
+
+  private readonly shader = rawShader(() => ({ vertexShader, fragmentShader }))
 
   @computed
   get lutSize() {

--- a/src/client/components/three/builders.ts
+++ b/src/client/components/three/builders.ts
@@ -1,3 +1,8 @@
+import { LinearMipMapLinearFilter } from 'three'
+import { NearestFilter } from 'three'
+import { InterleavedBuffer } from 'three'
+import { RawShaderMaterial } from 'three'
+import { BufferGeometry } from 'three'
 import { PlaneGeometry } from 'three'
 import { PointLight } from 'three'
 import { AmbientLight } from 'three'
@@ -40,7 +45,8 @@ type Object3DOpts = {
   rotationOrder?: string,
   scale?: Vector3,
   up?: Vector3,
-  children?: Object3D[]
+  children?: Array<Object3D | false | undefined>,
+  frustumCulled?: false
 }
 
 export type StageOpts = {
@@ -62,17 +68,22 @@ export const scene = createUpdatableComputed(
   (opts: Object3DOpts) => new Scene(),
   (scene, opts) => {
     scene.remove(...scene.children)
-    opts.children && scene.add(...opts.children)
+    const children = opts.children && opts.children.filter(truthy)
+    children && children.length && scene.add(...children)
     updateObject3D(scene, opts)
   },
   scene => scene.dispose(),
 )
 
 export const group = createUpdatableComputed(
-  (opts: Object3DOpts) => new Object3D(),
+  (opts: Object3DOpts | undefined) => opts && new Object3D(),
   (group, opts) => {
+    if (!group || !opts) {
+      return
+    }
     group.remove(...group.children)
-    opts.children && group.add(...opts.children)
+    const children = opts.children && opts.children.filter(truthy)
+    children && children.length && group.add(...children)
     updateObject3D(group, opts)
   },
 )
@@ -121,13 +132,13 @@ export const orthographicCamera = createUpdatableComputed(
   },
 )
 
-type MeshOpts = {
-  geometry: Geometry,
+type MeshOpts = Object3DOpts & {
+  geometry: Geometry | BufferGeometry,
   material: Material | Material[]
 }
 
 export const mesh = createUpdatableComputed(
-  (opts: MeshOpts & Object3DOpts) => new Mesh(opts.geometry, opts.material),
+  (opts: MeshOpts) => new Mesh(opts.geometry, opts.material),
   (mesh, opts) => {
     mesh.geometry = opts.geometry
     mesh.material = opts.material
@@ -135,7 +146,13 @@ export const mesh = createUpdatableComputed(
   },
 )
 
-type MeshBasicMaterialOpts = {
+type MaterialOpts = {
+  depthTest?: boolean,
+  depthWrite?: boolean,
+  transparent?: boolean
+}
+
+type MeshBasicMaterialOpts = MaterialOpts & {
   color?: Color,
   map?: Texture,
   transparent?: boolean,
@@ -156,10 +173,9 @@ export const meshBasicMaterial = createUpdatableComputed(
   mesh => mesh.dispose(),
 )
 
-type MeshPhongMaterialOpts = {
+type MeshPhongMaterialOpts = MaterialOpts & {
   color?: Color,
-  map?: Texture,
-  transparent?: boolean
+  map?: Texture
 }
 
 export const meshPhongMaterial = createUpdatableComputed(
@@ -167,30 +183,58 @@ export const meshPhongMaterial = createUpdatableComputed(
   (material, opts) => {
     material.color = opts.color || defaultColor
     material.map = opts.map || null
-    material.transparent = opts.transparent != null ? opts.transparent : false
+    updateMaterial(material, opts)
     material.needsUpdate = true
   },
   material => material.dispose(),
 )
 
-type ShaderMaterialOpts = {
+type ShaderOpts = {
   vertexShader: string
   fragmentShader: string
-  uniforms: { [uniform: string]: { value: any } }
 }
 
-export const shaderMaterial = createUpdatableComputed(
-  (opts: ShaderMaterialOpts) => new ShaderMaterial(opts),
+export const shader = createUpdatableComputed(
+  (opts: ShaderOpts) => new ShaderMaterial(opts),
   (material, opts) => {
     material.vertexShader = opts.vertexShader
     material.fragmentShader = opts.fragmentShader
-    for (const key of Object.keys(opts.uniforms)) {
-      material.uniforms[key] = opts.uniforms[key]
-    }
-    material.needsUpdate = true
   },
   material => material.dispose(),
 )
+
+export const rawShader = createUpdatableComputed(
+  (opts: ShaderOpts) => new RawShaderMaterial(opts),
+  (material, opts) => {
+    material.vertexShader = opts.vertexShader
+    material.fragmentShader = opts.fragmentShader
+  },
+  material => material.dispose(),
+)
+
+type ShaderMaterialOpts = MaterialOpts & {
+  shader(): ShaderMaterial | RawShaderMaterial;
+  uniforms?: { [uniform: string]: { value: any } }
+}
+
+export const shaderMaterial = createUpdatableComputed(
+  (opts: ShaderMaterialOpts) => opts.shader().clone(),
+  (material, opts) => {
+    if (opts.uniforms) {
+      for (const key of Object.keys(opts.uniforms)) {
+        material.uniforms[key] = opts.uniforms[key]
+      }
+    }
+    updateMaterial(material, opts)
+    material.needsUpdate = true
+  },
+)
+
+function updateMaterial(object: Material, opts: MaterialOpts) {
+  object.depthTest = opts.depthTest != null ? opts.depthTest : true
+  object.depthWrite = opts.depthWrite != null ? opts.depthWrite : true
+  object.transparent = opts.transparent != null ? opts.transparent : false
+}
 
 type TypedArray
   = Int8Array
@@ -207,27 +251,27 @@ type DataTextureOpts = {
   data: TypedArray,
   width: number,
   height: number,
-  format: PixelFormat,
-  type: TextureDataType,
-  mapping: Mapping,
-  wrapS: Wrapping,
-  wrapT: Wrapping,
-  magFilter: TextureFilter,
-  minFilter: TextureFilter,
-  flipY: boolean
+  format?: PixelFormat,
+  type?: TextureDataType,
+  mapping?: Mapping,
+  wrapS?: Wrapping,
+  wrapT?: Wrapping,
+  magFilter?: TextureFilter,
+  minFilter?: TextureFilter,
+  flipY?: boolean
 }
 
 export const dataTexture = createUpdatableComputed(
   (opts: DataTextureOpts) => new DataTexture(opts.data, opts.width, opts.height),
   (texture, opts) => {
-    texture.format = opts.format
-    texture.type = opts.type
-    texture.mapping = opts.mapping
-    texture.wrapS = opts.wrapS
-    texture.wrapT = opts.wrapT
-    texture.magFilter = opts.magFilter
-    texture.minFilter = opts.minFilter
-    texture.flipY = opts.flipY
+    texture.format = opts.format != null ? opts.format : RGBAFormat
+    texture.type = opts.type != null ? opts.type : UnsignedByteType
+    texture.mapping = opts.mapping != null ? opts.mapping : Texture.DEFAULT_MAPPING
+    texture.wrapS = opts.wrapS != null ? opts.wrapS : ClampToEdgeWrapping
+    texture.wrapT = opts.wrapT != null ? opts.wrapT : ClampToEdgeWrapping
+    texture.magFilter = opts.magFilter != null ? opts.magFilter : NearestFilter
+    texture.minFilter = opts.minFilter != null ? opts.minFilter : LinearMipMapLinearFilter
+    texture.flipY = opts.flipY != null ? opts.flipY : false
     texture.needsUpdate = true
   },
   texture => texture.dispose(),
@@ -244,8 +288,8 @@ type TextureOpts = {
 
 type ImageTextureOpts = TextureOpts & {
   image?: HTMLImageElement,
-  mapping: Mapping,
-  flipY: boolean
+  mapping?: Mapping,
+  flipY?: boolean
 }
 
 export const imageTexture = createUpdatableComputed(
@@ -256,7 +300,8 @@ export const imageTexture = createUpdatableComputed(
   (texture, opts) => {
     if (texture) {
       texture.image = opts.image
-      texture.flipY = opts.flipY
+      texture.flipY = opts.flipY != null ? opts.flipY : false
+      texture.mapping = opts.mapping != null ? opts.mapping : Texture.DEFAULT_MAPPING
       updateTexture(texture, opts)
       texture.needsUpdate = true
     }
@@ -319,6 +364,16 @@ export const planeGeometry = createUpdatableComputed(
   plane => plane.dispose(),
 )
 
+type InterleavedBufferOpts = {
+  buffer: TypedArray,
+  stride: number
+}
+
+export const interleavedBuffer = createUpdatableComputed(
+  (opts: InterleavedBufferOpts) => new InterleavedBuffer(opts.buffer, opts.stride),
+  buffer => buffer.needsUpdate = true,
+)
+
 type LightOpts = Object3DOpts & { color?: Color, intensity?: number }
 
 export const ambientLight = createUpdatableComputed(
@@ -344,4 +399,9 @@ function updateObject3D(object: Object3D, opts: Object3DOpts) {
   opts.rotation && object.rotation.set(opts.rotation.x, opts.rotation.y, opts.rotation.z, opts.rotationOrder)
   opts.scale && object.scale.set(opts.scale.x, opts.scale.y, opts.scale.z)
   opts.up && object.up.set(opts.up.x, opts.up.y, opts.up.z)
+  object.frustumCulled = opts.frustumCulled != null ? opts.frustumCulled : true
+}
+
+function truthy<T>(x: T | undefined | null | false): x is T {
+  return !!x
 }


### PR DESCRIPTION
Adding some functionality to the three builders in preparation for the vision rewrite. e.g.

1. Separated uniforms from the shader, to prevent recompilation
2. Allowed `false`/`undefined`/`null` in `group` children arrays, and automatically filter them (handy for conditional objects in render trees)
3. Made a bunch of image params optional, with defaults (which match three.js)
4. Add support for some new things, like `InterleavedBuffer` and `frustumCulled`