### PR TITLE
Fix crash in <GridLayout> when it has no children

### DIFF
--- a/src/client/components/vision/grid_layout/grid_layout.tsx
+++ b/src/client/components/vision/grid_layout/grid_layout.tsx
@@ -44,7 +44,7 @@ export class GridLayout extends Component<{
   @computed
   get gridTemplate() {
     const n = React.Children.count(this.props.children)
-    if (!this.width || !this.height) {
+    if (!this.width || !this.height || n < 2) {
       return '1fr'
     }
     const cols = bestFitCols({


### PR DESCRIPTION
`bestFitCols()` assumes there's at least one child, and crashes when there's none:

<img src="https://user-images.githubusercontent.com/5924865/95309564-08967100-08d7-11eb-994d-3baddb7b27f3.png" width="404px" />
