### PR TITLE
Allow running in Docker on Windows and macOS

### DIFF
--- a/docker
+++ b/docker
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Run `yarn ...` on `./docker yarn ...`
+if [ "$1" == "yarn" ]; then
+    shift 1
+    docker-compose run \
+        -p 3000:3000 \
+        -p 9090:9090 \
+        nusight \
+        yarn "$@"
+
+# Open a bash shell in the container on `./docker shell`
+elif [ "$1" == "shell" ]; then
+    shift 1
+    docker-compose run \
+        -p 3000:3000 \
+        -p 9090:9090 \
+        nusight \
+        bash
+
+# Otherwise show usage information
+else
+    echo "usage:"
+    echo "./docker yarn [command]   # run the given yarn command in a docker container"
+    echo "./docker shell            # open a bash shell in a docker container"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,12 @@ services:
     image: node:lts
     volumes:
       - .:/var/www/NUsight2
+      - node_modules_volume:/var/www/NUsight2/node_modules
     working_dir: /var/www/NUsight2
 networks:
   default:
     external:
       name: nuclearnet
+volumes:
+  node_modules_volume:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  nusight:
+    image: node:lts
+    volumes:
+      - .:/var/www/NUsight2
+    working_dir: /var/www/NUsight2
+networks:
+  default:
+    external:
+      name: nuclearnet


### PR DESCRIPTION
Pairs with https://github.com/NUbots/NUbots/pull/341.

This adds a simple docker-compose file for running NUsight in a docker container to get it to talk to NUbots in a container on Windows.

Using `docker-compose` (instead of just `docker`) allows for creating the container on demand without a Dockerfile + `docker build`.

It also adds a shell script to make it easier to run the docker-compose commands. I considered adding the commands as scripts to `package.json`, but `yarn` reports two spurious errors on SIGINT exit.

---

To be used as follows (proper NUbook documentation coming soon), all commands run in WSL on Windows:

### Setup

- Create the network: `docker network create nuclearnet`
- Make the docker script executable: `chmod +x ./docker`

### Build

- Install NUsight deps in the container `./docker yarn`
- Build NUsight for prod in the container `./docker yarn build`

### Run

- Run something in NUbots and connect it to the network: 
  ```sh
  ./b run keyboardwalkfake --network nuclearnet
  ```

- Inspect the network to find the NUbots container's IP address, X:
  ```sh
  docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nubots_generic
  ```

- Run NUsight with the NUbots container address:
  ```sh
  ./docker yarn prod --address X
  ```