### PR TITLE
Fix 3rd-party CSS files in development

### DIFF
--- a/build_scripts/build.ts
+++ b/build_scripts/build.ts
@@ -13,8 +13,8 @@ const opts: ConfigOptions = {
   mode: isProduction ? 'production' : 'development',
   context: path.join(__dirname, '..', 'src'),
   sourceMap: isContinuousIntegration ? false : 'source-map',
+  rootDir: path.join(__dirname, '..'),
 }
-webpack([getClientConfig(opts), getServerConfig(opts)])
-  .run((err, stats) => {
-    process.stdout.write(stats.toString({ colors: true }) + '\n')
-  })
+webpack([getClientConfig(opts), getServerConfig(opts)]).run((err, stats) => {
+  process.stdout.write(stats.toString({ colors: true }) + '\n')
+})

--- a/conf/storybook/webpack.config.ts
+++ b/conf/storybook/webpack.config.ts
@@ -9,6 +9,7 @@ export default ({ config: storybookConfig }: { config: webpack.Configuration }) 
     mode: 'development',
     context: path.resolve(path.join(__dirname, '..', '..', 'src')),
     sourceMap: 'eval-source-map',
+    rootDir: path.join(__dirname, '..', '..'),
   })
   return {
     ...config,
@@ -18,19 +19,23 @@ export default ({ config: storybookConfig }: { config: webpack.Configuration }) 
       rules: config.module && config.module.rules,
     },
     plugins: [
-      ...storybookConfig.plugins || [],
-      ...(config.plugins || []).filter(p => !(
-          p instanceof HtmlWebpackPlugin // Storybook handles page generation.
-          || p instanceof webpack.HotModuleReplacementPlugin // Disable HMR.
-          || p instanceof CopyWebpackPlugin // Avoids overwriting index.html.
-        ),
+      ...(storybookConfig.plugins || []),
+      ...(config.plugins || []).filter(
+        p =>
+          !(
+            (
+              p instanceof HtmlWebpackPlugin || // Storybook handles page generation.
+              p instanceof webpack.HotModuleReplacementPlugin || // Disable HMR.
+              p instanceof CopyWebpackPlugin
+            ) // Avoids overwriting index.html.
+          ),
       ),
     ],
     resolve: {
       ...storybookConfig.resolve,
       extensions: [
-        ...(storybookConfig.resolve && storybookConfig.resolve.extensions || []),
-        ...(config.resolve && config.resolve.extensions || []),
+        ...((storybookConfig.resolve && storybookConfig.resolve.extensions) || []),
+        ...((config.resolve && config.resolve.extensions) || []),
       ],
     },
   }

--- a/src/server/dev-server.ts
+++ b/src/server/dev-server.ts
@@ -23,6 +23,7 @@ const compiler = webpack(
     mode: 'development',
     context: path.join(__dirname, '..'),
     transpileOnly: args.t || args.transpileOnly || false,
+    rootDir: path.join(__dirname, '..', '..'),
   }),
 )
 

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -7,6 +7,7 @@ import favicon from 'serve-favicon'
 import sio from 'socket.io'
 import webpack from 'webpack'
 import webpackDevMiddleware from 'webpack-dev-middleware'
+import * as path from 'path'
 
 import { getClientConfig } from '../../webpack.config'
 import faviconPath from '../assets/favicon.ico'
@@ -26,6 +27,7 @@ const compiler = webpack(
     mode: 'development',
     context: args.context || undefined,
     transpileOnly: args.t || args.transpileOnly || false,
+    rootDir: path.join(__dirname, '..'),
   }),
 )
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -11,7 +11,7 @@ export type ConfigOptions = {
   context?: string
   sourceMap?: 'source-map' | 'eval-source-map' | false
   transpileOnly?: boolean
-  rootDir: string
+  rootDir?: string
 }
 
 export function getClientConfig({
@@ -19,7 +19,7 @@ export function getClientConfig({
   context,
   sourceMap,
   transpileOnly,
-  rootDir,
+  rootDir = __dirname,
 }: ConfigOptions): webpack.Configuration {
   const isProduction = mode === 'production'
   return {
@@ -166,7 +166,7 @@ export function getServerConfig({
   context,
   sourceMap,
   transpileOnly,
-  rootDir,
+  rootDir = __dirname,
 }: ConfigOptions): webpack.Configuration {
   return {
     mode,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -60,9 +60,9 @@ export function getClientConfig({
         {
           test: /\.css$/,
           exclude: [
-            isProduction
-              ? path.resolve(__dirname, 'node_modules')
-              : path.resolve(__dirname, '..', 'node_modules'), // __dirname is `nusight2/dist` in development
+            __dirname.endsWith(path.sep + 'dist') // __dirname is `[..]/dist` when built server is run in dev
+              ? path.resolve(__dirname, '..', 'node_modules')
+              : path.resolve(__dirname, 'node_modules'),
           ],
           use: ExtractTextPlugin.extract({
             fallback: 'style-loader',
@@ -100,9 +100,9 @@ export function getClientConfig({
         {
           test: /\.css$/,
           include: [
-            isProduction
-              ? path.resolve(__dirname, 'node_modules')
-              : path.resolve(__dirname, '..', 'node_modules'), // __dirname is `nusight2/dist` in development
+            __dirname.endsWith(path.sep + 'dist') // __dirname is `[..]/dist` when built server is run in dev
+              ? path.resolve(__dirname, '..', 'node_modules')
+              : path.resolve(__dirname, 'node_modules'),
           ],
           use: ['style-loader', 'css-loader'],
         },

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -59,7 +59,11 @@ export function getClientConfig({
         // local css
         {
           test: /\.css$/,
-          exclude: [path.resolve(__dirname, 'node_modules')],
+          exclude: [
+            isProduction
+              ? path.resolve(__dirname, 'node_modules')
+              : path.resolve(__dirname, '..', 'node_modules'), // __dirname is `nusight2/dist` in development
+          ],
           use: ExtractTextPlugin.extract({
             fallback: 'style-loader',
             use: [
@@ -95,7 +99,11 @@ export function getClientConfig({
         */
         {
           test: /\.css$/,
-          include: [path.resolve(__dirname, 'node_modules')],
+          include: [
+            isProduction
+              ? path.resolve(__dirname, 'node_modules')
+              : path.resolve(__dirname, '..', 'node_modules'), // __dirname is `nusight2/dist` in development
+          ],
           use: ['style-loader', 'css-loader'],
         },
         { test: /\.file.svg$/, use: 'url-loader' },

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -11,6 +11,7 @@ export type ConfigOptions = {
   context?: string
   sourceMap?: 'source-map' | 'eval-source-map' | false
   transpileOnly?: boolean
+  rootDir: string
 }
 
 export function getClientConfig({
@@ -18,6 +19,7 @@ export function getClientConfig({
   context,
   sourceMap,
   transpileOnly,
+  rootDir,
 }: ConfigOptions): webpack.Configuration {
   const isProduction = mode === 'production'
   return {
@@ -28,7 +30,7 @@ export function getClientConfig({
       main: './client/main.tsx',
     },
     output: {
-      path: path.join(__dirname, 'dist', 'public'),
+      path: path.join(rootDir, 'dist', 'public'),
       filename: '[name].js',
       publicPath: '/',
       globalObject: 'this',
@@ -47,7 +49,7 @@ export function getClientConfig({
         // .ts, .tsx
         {
           test: /\.tsx?$/,
-          exclude: [path.resolve(__dirname, 'node_modules')],
+          exclude: [path.resolve(rootDir, 'node_modules')],
           use: {
             loader: 'ts-loader',
             options: {
@@ -59,11 +61,7 @@ export function getClientConfig({
         // local css
         {
           test: /\.css$/,
-          exclude: [
-            __dirname.endsWith(path.sep + 'dist') // __dirname is `[..]/dist` when built server is run in dev
-              ? path.resolve(__dirname, '..', 'node_modules')
-              : path.resolve(__dirname, 'node_modules'),
-          ],
+          exclude: [path.resolve(rootDir, 'node_modules')],
           use: ExtractTextPlugin.extract({
             fallback: 'style-loader',
             use: [
@@ -99,11 +97,7 @@ export function getClientConfig({
         */
         {
           test: /\.css$/,
-          include: [
-            __dirname.endsWith(path.sep + 'dist') // __dirname is `[..]/dist` when built server is run in dev
-              ? path.resolve(__dirname, '..', 'node_modules')
-              : path.resolve(__dirname, 'node_modules'),
-          ],
+          include: [path.resolve(rootDir, 'node_modules')],
           use: ['style-loader', 'css-loader'],
         },
         { test: /\.file.svg$/, use: 'url-loader' },
@@ -172,6 +166,7 @@ export function getServerConfig({
   context,
   sourceMap,
   transpileOnly,
+  rootDir,
 }: ConfigOptions): webpack.Configuration {
   return {
     mode,
@@ -182,7 +177,7 @@ export function getServerConfig({
       ...(mode === 'development' ? { dev: './server/dev.ts' } : {}),
     },
     output: {
-      path: path.join(__dirname, 'dist'),
+      path: path.join(rootDir, 'dist'),
       filename: '[name].js',
       globalObject: 'this',
     },
@@ -195,7 +190,7 @@ export function getServerConfig({
       rules: [
         {
           test: /\.ts$/,
-          exclude: [path.resolve(__dirname, 'node_modules')],
+          exclude: [path.resolve(rootDir, 'node_modules')],
           use: {
             loader: 'ts-loader',
             options: {


### PR DESCRIPTION
The `include` and `exclude` loader checks (see below) for CSS files in `node_modules/` currently don't work in development, as `__dirname` is `nusight/dist/` when the webpack config file is built, not `nusight/`.

https://github.com/NUbots/NUsight2/blob/ed96ed4d23aa909e93a5ae8e72f037e7826e01d0/webpack.config.ts#L59-L62

https://github.com/NUbots/NUsight2/blob/ed96ed4d23aa909e93a5ae8e72f037e7826e01d0/webpack.config.ts#L92-L98